### PR TITLE
Fix file menu option exit

### DIFF
--- a/foundry/gui/util.py
+++ b/foundry/gui/util.py
@@ -44,7 +44,7 @@ def setup_widget_menu(widget: QMainWindow, flags):
                     else:
                         raise NotImplementedError
                     if option.get("wrapped", False):
-                        action.triggered.connect(lambda *_: method())
+                        action.triggered.connect(lambda *_, m=method: m())
                     else:
                         action.triggered.connect(method)
 


### PR DESCRIPTION
Closes: #36 

The lambda function did not enclose the outer scope's variable, which led to it only remembering the last method.  I fixed this issue, which allowed for the file menu to work again.