### PR TITLE
Add warning for downward vine

### DIFF
--- a/foundry/gui/WarningList.py
+++ b/foundry/gui/WarningList.py
@@ -15,7 +15,6 @@ from foundry.gui.LevelView import LevelView
 from foundry.gui.ObjectList import ObjectList
 from foundry.gui.util import clear_layout
 from foundry.smb3parse.constants import OBJ_AUTOSCROLL
-from foundry.smb3parse.objects.object_set import PLAINS_OBJECT_SET
 
 
 class WarningList(QWidget):
@@ -63,9 +62,6 @@ class WarningList(QWidget):
 
         # level objects to ground hitting the level edge
         for obj in level.objects:
-            if obj.object_info == (PLAINS_OBJECT_SET, 0, 0x06):
-                continue
-
             if obj.orientation in [GeneratorType.HORIZ_TO_GROUND, GeneratorType.PYRAMID_TO_GROUND]:
                 if obj.y_position + obj.rendered_height == GROUND:
                     self.warnings.append((f"{obj} extends until the level bottom. This can crash the game.", [obj]))


### PR DESCRIPTION
Closes: #18 

Add a warning for the downward vine if it extends to the bottom of the level as it is not correctly shown otherwise.