### PR TITLE
Remove error prone selections from JumpEditor

### DIFF
--- a/foundry/gui/MainWindow.py
+++ b/foundry/gui/MainWindow.py
@@ -1067,7 +1067,9 @@ class MainWindow(QMainWindow):
     def on_jump_edit(self):
         index = self.jump_list.currentIndex().row()
 
-        updated_jump = JumpEditor.edit_jump(self, self.level_view.level_ref.jumps[index])
+        updated_jump = JumpEditor.edit_jump(
+            self, self.level_view.level_ref.jumps[index], not self.level_view.level_ref.level.is_vertical
+        )
 
         self.on_jump_edited(updated_jump)
 

--- a/tests/gui/test_jump_editor.py
+++ b/tests/gui/test_jump_editor.py
@@ -18,7 +18,7 @@ def test_on_ok(main_window):
     # GIVEN a jump to be edited and the JumpEditor
     jump_before = main_window.level_ref.level.jumps[_jump_index]
 
-    jump_editor = JumpEditor(None, jump_before)
+    jump_editor = JumpEditor(None, jump_before, True)
 
     # WHEN the properties changed and the ok button pressed
     jump_editor.screen_spinner.setValue(jump_before.screen_index + 1)


### PR DESCRIPTION
Closes: #47 

Removed error prone selections from `JumpEditor`:
- Automatically updates vertical position, not requiring use input
- Only allows for valid actions