### PR TITLE
Fix JumpList using depricated PySide2 syntax

### DIFF
--- a/foundry/gui/JumpList.py
+++ b/foundry/gui/JumpList.py
@@ -44,7 +44,7 @@ class JumpList(QListWidget):
         self.addItems([str(jump) for jump in jumps])
 
     def contextMenuEvent(self, event: QContextMenuEvent):
-        item = self.itemAt(event.position())
+        item = self.itemAt(event.pos())
 
         menu = QMenu()
 


### PR DESCRIPTION
Closes: #49 

Fixed JumpList by using new PySide6 syntax `pos()` instead of `position`.  This restored the old usage.