### PR TITLE
Fix ObjectList not expanding properly

### DIFF
--- a/foundry/gui/ObjectList.py
+++ b/foundry/gui/ObjectList.py
@@ -10,6 +10,7 @@ class ObjectList(QListWidget):
         super(ObjectList, self).__init__(parent=parent)
 
         self.setSizePolicy(QSizePolicy.Maximum, QSizePolicy.Maximum)
+        self.setSizeAdjustPolicy(QListWidget.AdjustToContents)
 
         self.setSelectionMode(self.ExtendedSelection)
 


### PR DESCRIPTION
Closes: #23 

Fix ObjectList not expanding automatically by setting SizeAdjustPolicy to AdjustToContents. 