### PR TITLE
Fix title not updating on level select

### DIFF
--- a/foundry/game/level/LevelControlled.py
+++ b/foundry/game/level/LevelControlled.py
@@ -34,3 +34,6 @@ class LevelControlled(Protocol):
     @property
     def safe_to_change(self) -> bool:
         ...
+
+    def update_title(self):
+        ...

--- a/foundry/game/level/LevelController.py
+++ b/foundry/game/level/LevelController.py
@@ -264,6 +264,7 @@ class LevelController:
     def update_level(self, level_name: str, object_data_offset: int, enemy_data_offset: int, object_set: int):
         self.level_ref.load_level(level_name, object_data_offset, enemy_data_offset, object_set)
         self.update_gui_for_level()
+        self.parent.update_title()
 
     def update_gui_for_level(self):
         restore_all_palettes()


### PR DESCRIPTION
Closes: #70 

Updates the MainWindow's title for any given level update.  This ensures that the title will always be up to date.