### PR TITLE
Fix Foundry loading on invalid ROM

### DIFF
--- a/foundry/gui/MainWindow.py
+++ b/foundry/gui/MainWindow.py
@@ -169,7 +169,7 @@ class MainWindow(QMainWindow):
         QShortcut(QKeySequence(Qt.CTRL + Qt.Key_A), self, self.manager.select_all)
         QShortcut(QKeySequence(Qt.CTRL + Qt.Key_L), self, self.manager.focus_selected)
 
-        self.on_open_rom(path_to_rom)
+        self.loaded = self.on_open_rom(path_to_rom)
 
         self.showMaximized()
 
@@ -410,6 +410,9 @@ class MainWindow(QMainWindow):
         if not path_to_rom:
             # otherwise ask the user what new file to open
             path_to_rom, _ = QFileDialog.getOpenFileName(self, caption="Open ROM", filter=ROM_FILE_FILTER)
+        if not path_to_rom:
+            return False
+        print(path_to_rom)
 
         # Proceed loading the file chosen by the user
         try:

--- a/foundry/main.py
+++ b/foundry/main.py
@@ -36,10 +36,11 @@ def main(path_to_rom: str = ""):
                 None, "Auto Save recovered", "Don't forget to save the loaded ROM under a new name!"
             )
 
-    MainWindow(path_to_rom)
-    app.exec_()
-
-    save_settings()
+    window = MainWindow(path_to_rom)
+    if window.loaded:
+        del window.loaded
+        app.exec_()
+        save_settings()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes: #94, #95 

Fixes Foundry loading when no ROM is provided or the ROM is invalid.