### PR TITLE
Fix HeaderEditor not inheriting stylesheets

### DIFF
--- a/foundry/game/level/LevelController.py
+++ b/foundry/game/level/LevelController.py
@@ -287,7 +287,7 @@ class LevelController:
         self.parent.level_view.update()
 
     def display_header_editor(self):
-        header_editor = HeaderEditor(None, self.level_ref)
+        header_editor = HeaderEditor(self.parent, self.level_ref)  # type: ignore
         header_editor.tab_widget.setCurrentIndex(3)
         header_editor.exec_()
 

--- a/foundry/gui/HeaderEditor.py
+++ b/foundry/gui/HeaderEditor.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from PySide6.QtCore import Signal
-from PySide6.QtGui import Qt, QWindow
+from PySide6.QtGui import Qt
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -76,7 +76,7 @@ SPINNER_MAX_VALUE = 0x0F_FF_FF
 class HeaderEditor(CustomDialog):
     header_change: Signal = Signal()
 
-    def __init__(self, parent: Optional[QWindow], level_ref: LevelRef):
+    def __init__(self, parent: Optional[QWidget], level_ref: LevelRef):
         super(HeaderEditor, self).__init__(parent, "Level Header Editor")
 
         self.level: Level = level_ref.level

--- a/foundry/gui/JumpCreator.py
+++ b/foundry/gui/JumpCreator.py
@@ -28,6 +28,6 @@ class JumpCreator(QWidget):
         self.level_view.add_jump()
 
     def show_jump_dest(self):
-        header_editor = HeaderEditor(None, self.level_ref)
+        header_editor = HeaderEditor(self, self.level_ref)
         header_editor.tab_widget.setCurrentIndex(3)
         header_editor.exec_()


### PR DESCRIPTION
Closes: #104 

The HeaderEditor was not supplied an QWidget which caused it not to load the stylesheets properly.