### PR TITLE
Fix deselection of objects when changed

### DIFF
--- a/foundry/gui/ObjectList.py
+++ b/foundry/gui/ObjectList.py
@@ -90,6 +90,14 @@ class ObjectList(QListWidget):
 
         labels = [obj.name for obj in level_objects]
 
+        has_changes = False
+        for index, level_object in enumerate(level_objects):
+            if level_object.selected and index not in currently_selected:
+                has_changes = True
+                break
+        if not has_changes:
+            return
+
         self.blockSignals(True)
 
         self.clear()


### PR DESCRIPTION
Works on #114 

When editing an object with a spinner or through other hotkeys the object would be deselected.  This was caused by the ObjectList updating on every level update, resetting the selection.  I simply added a check so this would only occur when needed.