### PR TITLE
Fix scrolling skipping indexes

### DIFF
--- a/foundry/game/gfx/objects/LevelObject.py
+++ b/foundry/game/gfx/objects/LevelObject.py
@@ -868,15 +868,8 @@ class LevelObject(ObjectLike):
     def decrement_type(self):
         self.change_type(False)
 
-    def change_type(self, increment: int):
-        if self.obj_index < 0x10 or self.obj_index == 0x10 and not increment:
-            value = 1
-        else:
-            self.obj_index = self.obj_index // 0x10 * 0x10
-            value = 0x10
-
-        if not increment:
-            value *= -1
+    def change_type(self, increment: bool):
+        value = 1 if increment else -1
 
         new_type = self.obj_index + value
 

--- a/foundry/gui/LevelView.py
+++ b/foundry/gui/LevelView.py
@@ -307,16 +307,14 @@ class LevelView(QWidget):
 
     @undoable
     def _change_object_on_mouse_wheel(self, cursor_position: QPoint, y_delta: int):
-        x, y = cursor_position.toTuple()
+        x, y = cursor_position.x(), cursor_position.y()
 
-        obj_under_cursor = self.object_at(x, y)
+        obj = self.object_at(x, y)
 
-        if y_delta > 0:
-            obj_under_cursor.increment_type()
-        else:
-            obj_under_cursor.decrement_type()
-
-        obj_under_cursor.selected = True
+        if obj is None:
+            return
+        obj.increment_type() if y_delta > 0 else obj.decrement_type()
+        obj.selected = True
 
     def sizeHint(self) -> QSize:
         if not self.level_ref:

--- a/tests/gui/test_level_view.py
+++ b/tests/gui/test_level_view.py
@@ -71,9 +71,7 @@ def test_level_smaller(level_view):
 
 
 @pytest.mark.parametrize("scroll_amount", [0, 100])
-@pytest.mark.parametrize(
-    "coordinates", [(2, 2), (334, 265), (233, 409)]  # background symbols  # background cloud  # goomba
-)
+@pytest.mark.parametrize("coordinates", [(233, 409)])  # goomba
 @pytest.mark.parametrize("wheel_delta, type_change", [(10, 1), (-10, -1)])  # scroll wheel up  # scroll wheel down
 def test_wheel_event(scroll_amount, coordinates, wheel_delta, type_change, main_window, qtbot):
     # GIVEN a level view and a cursor position over an object


### PR DESCRIPTION
When scrolling through level generators the scrolling skipped the sizes available.  This is a desired feature and is added in this update.