### PR TITLE
Fix ObjectToolBox graphical glitch

### DIFF
--- a/foundry/gui/ObjectToolBox.py
+++ b/foundry/gui/ObjectToolBox.py
@@ -94,4 +94,5 @@ class ObjectToolBox(QWidget):
                 self.objects.pop(idx)
                 break
         self.objects.insert(0, object)
+        clear_layout(self._layout)
         self.update()


### PR DESCRIPTION
Fix ObjectToolBox graphical glitch where widgets were not deleted after creation.