### PR TITLE
Fix Title not updating from switching level internally

### DIFF
--- a/foundry/game/level/Level.py
+++ b/foundry/game/level/Level.py
@@ -30,12 +30,15 @@ LEVEL_DEFAULT_HEIGHT = 27
 LEVEL_DEFAULT_WIDTH = 16
 
 
-def world_and_level_for_level_address(level_address: int):
+def get_level_name_suggestion(level_address: int) -> str:
     for level in Level.offsets:
         if level.generator_pointer == level_address:
-            return level.display_information.locations[0].world, level.display_information.locations[0].index
+            name = level.display_information.name
+            if name is not None:
+                return name
+            return "Unspecified"
     else:
-        return -1, -1
+        return "Unknown"
 
 
 class LevelSignaller(QObject):

--- a/foundry/game/level/LevelController.py
+++ b/foundry/game/level/LevelController.py
@@ -12,7 +12,7 @@ from foundry.game.File import ROM
 from foundry.game.gfx.objects.EnemyItem import EnemyObject
 from foundry.game.gfx.objects.LevelObject import LevelObject
 from foundry.game.gfx.Palette import restore_all_palettes
-from foundry.game.level.Level import Level, world_and_level_for_level_address
+from foundry.game.level.Level import Level, get_level_name_suggestion
 from foundry.game.level.LevelControlled import LevelControlled
 from foundry.game.level.LevelRef import LevelRef
 from foundry.gui.AutoScrollEditor import AutoScrollEditor
@@ -83,9 +83,9 @@ class LevelController:
         enemy_address = self.level_ref.level.next_area_enemies + 1
         object_set = self.level_ref.level.next_area_object_set
 
-        world, level = world_and_level_for_level_address(level_address)
-
-        self.update_level(f"Level {world}-{level}", level_address, enemy_address, object_set)
+        self.update_level(
+            f"Level {get_level_name_suggestion(level_address + 9)}", level_address, enemy_address, object_set
+        )
 
     @require_safe_to_change
     def on_select(self):


### PR DESCRIPTION
Closes: #127 

When selecting a title from a warp, it was incongruent with the other methods inside the game.  Now it loads from the JSON specified display name.  It also supplied the wrong pointer to the JSON supplied offsets.  This has also bene mended.