### PR TITLE
Add size warnings for level objects

### DIFF
--- a/foundry/core/warnings/InvalidSizeWarning.py
+++ b/foundry/core/warnings/InvalidSizeWarning.py
@@ -1,0 +1,65 @@
+from typing import Optional
+
+from attr import attrs
+
+from foundry.core.warnings.Warning import PydanticWarning, Warning
+from foundry.game.gfx.objects.LevelObject import LevelObject
+
+
+@attrs(slots=True, frozen=True, auto_attribs=True)
+class InvalidSizeWarning(Warning):
+    """
+    A warning for an object exceeding its valid size range.
+    """
+
+    max_width: Optional[int] = None
+    min_width: Optional[int] = None
+    max_height: Optional[int] = None
+    min_height: Optional[int] = None
+
+    def check_object(self, obj: LevelObject, *args, **kwargs) -> bool:
+        """
+        Determines if the object should emit a warning for having an invalid size.
+
+        Parameters
+        ----------
+        obj : ObjectLike
+            The object to check.
+
+        Returns
+        -------
+        bool
+            If the object should emit a warning.
+        """
+        return (
+            self.max_width is not None
+            and obj.rendered_width > self.max_width
+            or self.min_width is not None
+            and obj.rendered_width < self.min_width
+            or self.max_height is not None
+            and obj.rendered_height > self.max_height
+            or self.min_height is not None
+            and obj.rendered_height < self.min_height
+        )
+
+    def get_message(self, obj: LevelObject) -> str:
+        if self.max_width is not None and obj.rendered_width > self.max_width:
+            return f"{obj.name} width of {obj.rendered_width} is more than its safe maximum of {self.max_width}."
+        if self.min_width is not None and obj.rendered_width < self.min_width:
+            return f"{obj.name} width of {obj.rendered_width} is less than its safe minimum of {self.min_width}."
+        if self.max_height is not None and obj.rendered_height > self.max_height:
+            return f"{obj.name} height of {obj.rendered_height} is more than its safe maximum of {self.max_height}."
+        if self.min_height is not None and obj.rendered_height < self.min_height:
+            return f"{obj.name} height of {obj.rendered_height} is less than its safe maximum of {self.min_height}."
+        raise NotImplementedError
+
+
+class PydanticInvalidSizeWarning(PydanticWarning):
+    """
+    A JSON model of a warning that checks for an object being in a size range.
+    """
+
+    max_width: Optional[int] = None
+    min_width: Optional[int] = None
+    max_height: Optional[int] = None
+    min_height: Optional[int] = None

--- a/foundry/core/warnings/WarningType.py
+++ b/foundry/core/warnings/WarningType.py
@@ -4,6 +4,7 @@ from enum import Enum
 class WarningType(str, Enum):
     invalid_type = "INVALID OBJECT"
     invalid_position = "INVALID POSITION"
+    invalid_size = "INVALID SIZE"
     invalid_extension_to_ground = "INVALID EXTENSION TO GROUND"
     outside_level_bounds = "OUTSIDE LEVEL BOUNDS"
     enemy_compatibility = "ENEMY COMPATIBILITY"

--- a/foundry/core/warnings/util.py
+++ b/foundry/core/warnings/util.py
@@ -25,6 +25,7 @@ def type_to_pydantic_warning() -> dict[WarningType, Type[PydanticWarning]]:
     from foundry.core.warnings.InvalidPositionWarning import (
         PydanticInvalidPositionWarning,
     )
+    from foundry.core.warnings.InvalidSizeWarning import PydanticInvalidSizeWarning
     from foundry.core.warnings.InvalidWarpWarning import PydanticInvalidWarpWarning
     from foundry.core.warnings.OutsideLevelBoundsWarning import (
         PydanticOutsideLevelBoundsWarning,
@@ -35,6 +36,7 @@ def type_to_pydantic_warning() -> dict[WarningType, Type[PydanticWarning]]:
         WarningType.invalid_extension_to_ground: PydanticExtendToGroundWarning,
         WarningType.invalid_type: PydanticInvalidObjectWarning,
         WarningType.invalid_position: PydanticInvalidPositionWarning,
+        WarningType.invalid_size: PydanticInvalidSizeWarning,
         WarningType.invalid_warp: PydanticInvalidWarpWarning,
         WarningType.outside_level_bounds: PydanticOutsideLevelBoundsWarning,
     }
@@ -56,6 +58,7 @@ def type_to_warning() -> dict[WarningType, Type[Warning]]:
     from foundry.core.warnings.ExtendToGroundWarning import ExtendToGroundWarning
     from foundry.core.warnings.InvalidObjectWarning import InvalidObjectWarning
     from foundry.core.warnings.InvalidPositionWarning import InvalidPositionWarning
+    from foundry.core.warnings.InvalidSizeWarning import InvalidSizeWarning
     from foundry.core.warnings.InvalidWarpWarning import InvalidWarpWarning
     from foundry.core.warnings.OutsideLevelBoundsWarning import (
         OutsideLevelBoundsWarning,
@@ -66,6 +69,7 @@ def type_to_warning() -> dict[WarningType, Type[Warning]]:
         WarningType.invalid_extension_to_ground: ExtendToGroundWarning,
         WarningType.invalid_type: InvalidObjectWarning,
         WarningType.invalid_position: InvalidPositionWarning,
+        WarningType.invalid_size: InvalidSizeWarning,
         WarningType.invalid_warp: InvalidWarpWarning,
         WarningType.outside_level_bounds: OutsideLevelBoundsWarning,
     }

--- a/foundry/data/definitions.json
+++ b/foundry/data/definitions.json
@@ -2943,7 +2943,8 @@
       "orientation": 0,
       "ending": 3,
       "size": 4,
-      "description": "Flat Ground"
+      "description": "Flat Ground",
+      "warnings": [{ "type": "INVALID SIZE", "min_width": 3 }]
     },
     {
       "domain": 0,
@@ -2955,7 +2956,8 @@
       "orientation": 0,
       "ending": 3,
       "size": 4,
-      "description": "Underwater Flat Ground"
+      "description": "Underwater Flat Ground",
+      "warnings": [{ "type": "INVALID SIZE", "min_width": 3 }]
     },
     {
       "domain": 0,
@@ -7575,7 +7577,8 @@
       "orientation": 0,
       "ending": 3,
       "size": 4,
-      "description": "Flat Ground with green on top (SMAS only)"
+      "description": "Flat Ground with green on top (SMAS only)",
+      "warnings": [{ "type": "INVALID SIZE", "min_width": 3 }]
     },
     {
       "domain": 5,
@@ -14315,7 +14318,8 @@
       "blocks": [226, 228, 229],
       "orientation": 0,
       "ending": 3,
-      "description": "Wooden Ship Beam"
+      "description": "Wooden Ship Beam",
+      "warnings": [{ "type": "INVALID SIZE", "min_width": 3 }]
     },
     {
       "domain": 0,
@@ -14327,7 +14331,8 @@
       "orientation": 0,
       "ending": 3,
       "size": 4,
-      "description": "Wooden Ship Beam"
+      "description": "Wooden Ship Beam",
+      "warnings": [{ "type": "INVALID SIZE", "min_width": 3 }]
     },
     {
       "domain": 0,
@@ -14339,7 +14344,8 @@
       "orientation": 0,
       "ending": 3,
       "size": 4,
-      "description": "Wooden Ship Beam with 2 strips of wood"
+      "description": "Wooden Ship Beam with 2 strips of wood",
+      "warnings": [{ "type": "INVALID SIZE", "min_width": 3 }]
     },
     {
       "domain": 0,
@@ -28695,7 +28701,8 @@
       "orientation": 0,
       "ending": 3,
       "size": 4,
-      "description": "Icy flat ground"
+      "description": "Icy flat ground",
+      "warnings": [{ "type": "INVALID SIZE", "min_width": 3 }]
     },
     {
       "domain": 0,
@@ -33444,7 +33451,8 @@
       "orientation": 0,
       "ending": 3,
       "size": 4,
-      "description": "Flat Ground with green on top (SMAS only)"
+      "description": "Flat Ground with green on top (SMAS only)",
+      "warnings": [{ "type": "INVALID SIZE", "min_width": 3 }]
     },
     {
       "domain": 5,

--- a/tests/core/warnings/__init__.py
+++ b/tests/core/warnings/__init__.py
@@ -8,6 +8,7 @@ class ObjectLike:
     x: int = 0
     y: int = 0
     name: str = ""
+    rendered_width: int = 0
     rendered_height: int = 0
 
     def get_rect(self):

--- a/tests/core/warnings/test_invalid_size_warning.py
+++ b/tests/core/warnings/test_invalid_size_warning.py
@@ -1,0 +1,24 @@
+from hypothesis import given
+from hypothesis.strategies import builds, integers
+
+from foundry.core.warnings.InvalidSizeWarning import InvalidSizeWarning
+from tests.core.warnings.conftest import object_like
+
+
+def size_warning():
+    return builds(InvalidSizeWarning, integers(), integers(), integers(), integers())
+
+
+def test_initalization():
+    InvalidSizeWarning()
+
+
+@given(object_like(), size_warning())
+def test_check_object_no_level(object_like, warning):
+    assert isinstance(warning.check_object(object_like), bool)
+
+
+@given(object_like(), size_warning())
+def test_get_message(object_like, warning):
+    if warning.check_object(object_like):
+        assert isinstance(warning.get_message(object_like), str)


### PR DESCRIPTION
Closes: #132 

- Add size warnings for level objects
- Add width warning for flat ground
- Add width warning for icy ground
- Add width warning for ship beams