### PR TITLE
Generator refactor and small fixes

### DIFF
--- a/foundry/core/warnings/ExtendToGroundWarning.py
+++ b/foundry/core/warnings/ExtendToGroundWarning.py
@@ -22,7 +22,7 @@ class ExtendToGroundWarning(Warning):
         bool
             If the object should emit a warning.
         """
-        return obj.position.y + obj.rendered_height == 27
+        return obj.position.y + obj.rendered_size.height == 27
 
     def get_message(self, obj: ObjectLike) -> str:
         return f"{obj} extends until the level bottom. This can crash the game."

--- a/foundry/core/warnings/InvalidSizeWarning.py
+++ b/foundry/core/warnings/InvalidSizeWarning.py
@@ -33,24 +33,28 @@ class InvalidSizeWarning(Warning):
         """
         return (
             self.max_width is not None
-            and obj.rendered_width > self.max_width
+            and obj.rendered_size.width > self.max_width
             or self.min_width is not None
-            and obj.rendered_width < self.min_width
+            and obj.rendered_size.width < self.min_width
             or self.max_height is not None
-            and obj.rendered_height > self.max_height
+            and obj.rendered_size.height > self.max_height
             or self.min_height is not None
-            and obj.rendered_height < self.min_height
+            and obj.rendered_size.height < self.min_height
         )
 
     def get_message(self, obj: LevelObject) -> str:
-        if self.max_width is not None and obj.rendered_width > self.max_width:
-            return f"{obj.name} width of {obj.rendered_width} is more than its safe maximum of {self.max_width}."
-        if self.min_width is not None and obj.rendered_width < self.min_width:
-            return f"{obj.name} width of {obj.rendered_width} is less than its safe minimum of {self.min_width}."
-        if self.max_height is not None and obj.rendered_height > self.max_height:
-            return f"{obj.name} height of {obj.rendered_height} is more than its safe maximum of {self.max_height}."
-        if self.min_height is not None and obj.rendered_height < self.min_height:
-            return f"{obj.name} height of {obj.rendered_height} is less than its safe maximum of {self.min_height}."
+        if self.max_width is not None and obj.rendered_size.width > self.max_width:
+            return f"{obj.name} width of {obj.rendered_size.width} is more than its safe maximum of {self.max_width}."
+        if self.min_width is not None and obj.rendered_size.width < self.min_width:
+            return f"{obj.name} width of {obj.rendered_size.width} is less than its safe minimum of {self.min_width}."
+        if self.max_height is not None and obj.rendered_size.height > self.max_height:
+            return (
+                f"{obj.name} height of {obj.rendered_size.height} is more than its safe maximum of {self.max_height}."
+            )
+        if self.min_height is not None and obj.rendered_size.height < self.min_height:
+            return (
+                f"{obj.name} height of {obj.rendered_size.height} is less than its safe maximum of {self.min_height}."
+            )
         raise NotImplementedError
 
 

--- a/foundry/game/gfx/GraphicsSet.py
+++ b/foundry/game/gfx/GraphicsSet.py
@@ -13,6 +13,8 @@ WORLD_MAP = 0
 SPADE_ROULETTE = 16
 N_SPADE = 17
 VS_2P = 18
+HILLY = 3
+CORRECTED_HILLY = 19
 
 BG_PAGE_COUNT = Level_BG_Pages2 - Level_BG_Pages1  # 23 in stock rom
 
@@ -143,6 +145,8 @@ class GraphicsSet:
             return cls(
                 (GraphicalPage(index), GraphicalPage(index + 1), GraphicalPage(index + 2), GraphicalPage(index + 3))
             )
+        if index == HILLY:
+            index = CORRECTED_HILLY
 
         graphic_page_index_1 = ROM().bulk_read(BG_PAGE_COUNT, Level_BG_Pages1)
         graphic_page_index_2 = ROM().bulk_read(BG_PAGE_COUNT, Level_BG_Pages2)

--- a/foundry/gui/BlockEditor.py
+++ b/foundry/gui/BlockEditor.py
@@ -220,5 +220,10 @@ class BlockEditorView(QWidget):
         bg_color = self.palette_group[0][0]
         painter.setBrush(QBrush(bg_color))
         painter.drawRect(QRect(QPoint(0, 0), self.size()))
-        block = Block(self.block_index, self.palette_group, self.graphics_set, self.tsa_data)
+        block = Block(
+            self.block_index,
+            tuple(tuple(c for c in pal) for pal in self.palette_group),
+            self.graphics_set,
+            self.tsa_data,
+        )
         block.draw(painter, 0, 0, self.block_scale)

--- a/foundry/gui/LevelDrawer.py
+++ b/foundry/gui/LevelDrawer.py
@@ -402,7 +402,7 @@ class LevelDrawer:
                 continue
 
             if fill_object:
-                for x in range(level_object.rendered_width):
+                for x in range(level_object.rendered_size.width):
                     adapted_pos = QPoint(pos)
                     adapted_pos.setX(pos.x() + x * self.block_length)
 

--- a/tests/core/warnings/__init__.py
+++ b/tests/core/warnings/__init__.py
@@ -1,6 +1,7 @@
 from attr import attrs
 
 from foundry.core.Position import Position
+from foundry.core.Size import Size
 
 
 @attrs(slots=True, frozen=True, auto_attribs=True)
@@ -17,3 +18,7 @@ class ObjectLike:
     @property
     def position(self) -> Position:
         return Position(self.x, self.y)
+
+    @property
+    def rendered_size(self) -> Size:
+        return Size(self.rendered_width, self.rendered_height)

--- a/tests/game/level/test_level.py
+++ b/tests/game/level/test_level.py
@@ -92,5 +92,5 @@ def test_level_insert_in_vertical_level(level):
 
     assert added_object.domain == domain
     assert added_object.obj_index == object_index
-    assert added_object.rendered_base_x == x
-    assert added_object.rendered_base_y == y
+    assert added_object.rendered_position.x == x
+    assert added_object.rendered_position.y == y


### PR DESCRIPTION
Closes: #149, #150 

- Refactor generators render function into three parts: rendering, size, and position
- Fix BlockEditor not hashing the palette group resulting in a crash
- Fix the Hilly graphic set being improperly set.