### PR TITLE
HeaderEditor Overhaul

### DIFF
--- a/docs/source/foundry.game.level.rst
+++ b/docs/source/foundry.game.level.rst
@@ -4,10 +4,10 @@ foundry.game.level package
 Submodules
 ----------
 
-foundry.game.level.Level module
+foundry.game.level.PydanticLevel module
 -------------------------------
 
-.. automodule:: foundry.game.level.Level
+.. automodule:: foundry.game.level.PydanticLevel
    :members:
    :undoc-members:
    :show-inheritance:

--- a/foundry/__init__.py
+++ b/foundry/__init__.py
@@ -14,6 +14,9 @@ home_dir.mkdir(parents=True, exist_ok=True)
 
 default_settings_path = home_dir / "settings"
 
+file_settings_path = home_dir / "file_settings"
+file_settings_path.mkdir(parents=True, exist_ok=True)
+
 auto_save_path = home_dir / "auto_save"
 auto_save_path.mkdir(parents=True, exist_ok=True)
 
@@ -22,6 +25,8 @@ auto_save_m3l_path = auto_save_path / "auto_save.m3l"
 auto_save_level_data_path = auto_save_path / "level_data.json"
 
 data_dir = root_dir / "data"
+default_levels_path = data_dir / "levels.json"
+default_styles_path = data_dir / "gui_styles.json"
 main_window_flags_path = data_dir / "main_window_flags.json"
 jump_creator_flags_path = data_dir / "jump_creator_flags.json"
 spinner_panel_flags_path = data_dir / "spinner_panel_flags.json"

--- a/foundry/core/UndoController.py
+++ b/foundry/core/UndoController.py
@@ -45,6 +45,13 @@ class UndoController(Generic[T]):
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.state}, {self.undo_stack}, {self.redo_stack})"
 
+    def __eq__(self, other) -> bool:
+        return (
+            self.state == other.state and self.undo_stack == other.undo_stack and self.redo_stack == other.redo_stack
+            if isinstance(other, UndoController)
+            else False
+        )
+
     @property
     def state(self) -> T:
         return self._state

--- a/foundry/core/validators.py
+++ b/foundry/core/validators.py
@@ -1,0 +1,54 @@
+from typing import Any, Callable, Optional
+
+
+def range_validator(minimum: Optional[int] = None, maximum: Optional[int] = None) -> Callable[[Any, Any, int], int]:
+    """
+    A validator for an ~`attrs.attrs` dataclass that ensures an int is between a minimum and maximum value.
+
+    Parameters
+    ----------
+    minimum : Optional[int]
+        The minimum value that the value is permitted to be.  If minimum is None, then there will be no bound for the
+        minimum value.  By default, None.
+    maximum : Optional[int]
+        The maximum value that the value is permitted to be.  If maximum is None, then there will be no bound for the
+        maximum value.  By default, None.
+
+    Returns
+    -------
+    Callable[[Any, Any, int], int]
+        A callable that acts as the true validator with a predefined minimum and maximum value.
+    """
+
+    def range_validator(instance: Any, attribute: Any, value: int) -> int:
+        """
+        Validates a value is between a predefined minimum and maximum value.
+
+        Parameters
+        ----------
+        instance : Any
+            The instance that's being validated.
+        attribute : Any
+            The attribute that it's validating.
+        value : int
+            The value that is passed for it.
+
+        Returns
+        -------
+        int
+            The value that is passed for it.
+
+        Raises
+        ------
+        ValueError
+            Raised when the value is less than the minimum value.
+        ValueError
+            Raised when the value is greater than the maximum value.
+        """
+        if minimum is not None and value < minimum:
+            raise ValueError(f"{value} is less than the minimum possible input {minimum}")
+        if maximum is not None and value > maximum:
+            raise ValueError(f"{value} is greater than the maximum possible input {maximum}")
+        return value
+
+    return range_validator

--- a/foundry/core/warnings/EnemyCompatibilityWarning.py
+++ b/foundry/core/warnings/EnemyCompatibilityWarning.py
@@ -56,7 +56,7 @@ class EnemyCompatibilityWarning(Warning):
         ----------
         obj : EnemyObject
             The object to check.
-        level : Level
+        level : PydanticLevel
             The level the object is housed inside.
         index : int
             The index into the level enemies obj is housed.

--- a/foundry/core/warnings/InvalidWarpWarning.py
+++ b/foundry/core/warnings/InvalidWarpWarning.py
@@ -16,7 +16,7 @@ class InvalidWarpWarning(Warning):
         ----------
         obj : Jump
             The jump to check.
-        level : Optional[Level]
+        level : Optional[PydanticLevel]
             The level to check the warps of.
 
         Returns
@@ -31,7 +31,7 @@ class InvalidWarpWarning(Warning):
         return level is not None and not level.has_next_area
 
     def get_message(self, obj: ObjectLike) -> str:
-        return f"Level has {obj}, but no Jump Destination in Level Header."
+        return f"PydanticLevel has {obj}, but no Jump Destination in PydanticLevel Header."
 
 
 class PydanticInvalidWarpWarning(PydanticWarning):

--- a/foundry/core/warnings/OutsideLevelBoundsWarning.py
+++ b/foundry/core/warnings/OutsideLevelBoundsWarning.py
@@ -15,7 +15,7 @@ class OutsideLevelBoundsWarning(Warning):
         ----------
         obj : ObjectLike
             The object to check.
-        level : Optional[Level]
+        level : Optional[PydanticLevel]
             The level to check the bounds of.
 
         Returns

--- a/foundry/data/gui_styles.json
+++ b/foundry/data/gui_styles.json
@@ -1,0 +1,20 @@
+{
+  "DARK AMBER": "dark_amber.xml",
+  "DARK BLUE": "dark_blue.xml",
+  "DARK CYAN": "dark_cyan.xml",
+  "DARK GREEN": "dark_lightgreen.xml",
+  "DARK PINK": "dark_pink.xml",
+  "DARK PURPLE": "dark_purple.xml",
+  "DARK RED": "dark_red.xml",
+  "DARK TEAL": "dark_teal.xml",
+  "DARK YELLOW": "dark_yellow.xml",
+  "LIGHT AMBER": "light_amber.xml",
+  "LIGHT BLUE": "light_blue.xml",
+  "LIGHT CYAN": "light_cyan.xml",
+  "LIGHT GREEN": "light_lightgreen.xml",
+  "LIGHT PINK": "light_pink.xml",
+  "LIGHT PURPLE": "light_purple.xml",
+  "LIGHT RED": "light_red.xml",
+  "LIGHT TEAL": "light_teal.xml",
+  "LIGHT YELLOW": "light_yellow.xml"
+}

--- a/foundry/game/Data.py
+++ b/foundry/game/Data.py
@@ -52,16 +52,16 @@ map_sprite_names = [
 
 obj_sets = [
     "Map Screen",
-    "Plains Level",
-    "Hilly/Underground Level",
-    "Sky Level",
+    "Plains PydanticLevel",
+    "Hilly/Underground PydanticLevel",
+    "Sky PydanticLevel",
     "Dungeon",
     "Airship",
-    "Cloudy Level",
-    "Desert Level",
-    "Water/Pipe Level",
-    "Giant Level",
-    "Ice Level",
+    "Cloudy PydanticLevel",
+    "Desert PydanticLevel",
+    "Water/Pipe PydanticLevel",
+    "Giant PydanticLevel",
+    "Ice PydanticLevel",
 ]
 
 mushroom_houses = [

--- a/foundry/game/level/Level.py
+++ b/foundry/game/level/Level.py
@@ -103,7 +103,7 @@ class Level(LevelLike):
 
     @property
     def fully_loaded(self):
-        """Whether this object represents a fully loaded Level, meaning it was either loaded from a ROM or from an m3l
+        """Whether this object represents a fully loaded PydanticLevel, meaning it was either loaded from a ROM or from an m3l
         file. If this is false, it is probably just a place holder to use either from_bytes or from_m3l later."""
         # objects, enemies and jumps could be empty, but there are always 9 header bytes, when a level is loaded
         return bool(self.header_bytes)

--- a/foundry/game/level/LevelController.py
+++ b/foundry/game/level/LevelController.py
@@ -83,12 +83,12 @@ class LevelController:
         object_set = self.level_ref.level.next_area_object_set
 
         self.update_level(
-            f"Level {get_level_name_suggestion(level_address + 9)}", level_address, enemy_address, object_set
+            f"PydanticLevel {get_level_name_suggestion(level_address + 9)}", level_address, enemy_address, object_set
         )
 
     @require_safe_to_change
     def on_select(self):
-        selector = LevelSelector(self.parent, start_level=self.level_selector_last_level)
+        selector = LevelSelector(self.parent, ROM().settings, start_level=self.level_selector_last_level)
 
         if QDialog.Accepted == selector.exec():
             self.level_selector_last_level = selector.current_level_index

--- a/foundry/game/level/util.py
+++ b/foundry/game/level/util.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from foundry import data_dir, default_levels_path
 
 
-@attrs(auto_attribs=True, slots=True)
+@attrs(auto_attribs=True, slots=True, frozen=True)
 class Location:
     """
     A representation of a location of a level.
@@ -22,7 +22,7 @@ class Location:
     index: int
 
 
-@attrs(auto_attribs=True, slots=True)
+@attrs(auto_attribs=True, slots=True, frozen=True)
 class DisplayInformation:
     """
     The display information to nicely sort levels.
@@ -42,7 +42,7 @@ class DisplayInformation:
     locations: list[Location]
 
 
-@attrs(auto_attribs=True, slots=True)
+@attrs(auto_attribs=True, slots=True, frozen=True, repr=False)
 class Level:
     """
     The representation of a level inside the game.
@@ -69,6 +69,12 @@ class Level:
     tileset: int
     generator_size: int
     enemy_size: int
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}({self.display_information}, {hex(self.generator_pointer)}, "
+            + f"{hex(self.enemy_pointer)}, {self.tileset}, {self.generator_size}, {self.enemy_size})"
+        )
 
 
 class PydanticLocation(BaseModel):
@@ -273,6 +279,52 @@ def get_world_levels(world: int, levels: list[Level]) -> list[Level]:
             if location.world == world:
                 world_levels[location.index] = level
     return [element[1] for element in sorted(world_levels.items(), key=lambda item: item[0])]
+
+
+def find_level_by_pointers(levels: list[Level], generator_pointer: int, enemy_pointer: int) -> Optional[Level]:
+    """
+    Finds a level by its pointers.
+
+    Parameters
+    ----------
+    levels : list[Level]
+        The levels to search through.
+    generator_pointer : int
+        The generator pointer of the level to find.
+    enemy_pointer : int
+        The enemy pointer of the level to find.
+
+    Returns
+    -------
+    Optional[Level]
+        The level, if one is found.
+    """
+    for level in levels:
+        if level.generator_pointer == generator_pointer and level.enemy_pointer == enemy_pointer:
+            return level
+
+
+def get_level_index(levels: list[Level], generator_pointer: int, enemy_pointer: int) -> int:
+    """
+    Finds a level by its pointers and sets it to the incoming value.
+
+    Parameters
+    ----------
+    levels : list[Level]
+        The levels to search through.
+    generator_pointer : int
+        The generator pointer of the level to find.
+    enemy_pointer : int
+        The enemy pointer of the level to find.
+
+    Returns
+    -------
+    int
+        The index of the level
+    """
+    for index, level in enumerate(levels):
+        if level.generator_pointer == generator_pointer and level.enemy_pointer == enemy_pointer:
+            return index
 
 
 def get_worlds(levels: list[PydanticLevel]) -> int:

--- a/foundry/game/level/util.py
+++ b/foundry/game/level/util.py
@@ -1,12 +1,14 @@
 from json import loads
 from typing import Optional
 
+from attr import attrs
 from pydantic import BaseModel
 
-from foundry import data_dir
+from foundry import data_dir, default_levels_path
 
 
-class Location(BaseModel):
+@attrs(auto_attribs=True, slots=True)
+class Location:
     """
     A representation of a location of a level.
 
@@ -20,7 +22,8 @@ class Location(BaseModel):
     index: int
 
 
-class DisplayInformation(BaseModel):
+@attrs(auto_attribs=True, slots=True)
+class DisplayInformation:
     """
     The display information to nicely sort levels.
 
@@ -39,7 +42,8 @@ class DisplayInformation(BaseModel):
     locations: list[Location]
 
 
-class Level(BaseModel):
+@attrs(auto_attribs=True, slots=True)
+class Level:
     """
     The representation of a level inside the game.
 
@@ -67,6 +71,182 @@ class Level(BaseModel):
     enemy_size: int
 
 
+class PydanticLocation(BaseModel):
+    """
+    A representation of a location of a level.
+
+    world: int
+        The world the level is located inside.
+    index: int
+        The index the level is inside the world.
+    """
+
+    world: int
+    index: int
+
+    def to_location(self) -> Location:
+        """
+        Converts the instance to a dataclass to be more easily modified.
+
+        Returns
+        -------
+        Location
+            The location representation of this instance.
+        """
+        return Location(self.world, self.index)
+
+
+class PydanticDisplayInformation(BaseModel):
+    """
+    The display information to nicely sort levels.
+
+    Attributes
+    ----------
+    name: Optional[str]
+        The name of the level.
+    description: Optional[str]
+        The description of the level.
+    locations: list[PydanticLocation]
+        The locations that the level is inside.
+    """
+
+    name: Optional[str]
+    description: Optional[str]
+    locations: list[PydanticLocation]
+
+    def to_display_information(self) -> DisplayInformation:
+        """
+        Converts the instance to a dataclass to be more easily modified.
+
+        Returns
+        -------
+        DisplayInformation
+            The display information representation of this instance.
+        """
+        return DisplayInformation(self.name, self.description, [loc.to_location() for loc in self.locations])
+
+
+class PydanticLevel(BaseModel):
+    """
+    The representation of a level inside the game.
+
+    Attributes
+    ----------
+    display_information: PydanticDisplayInformation
+        Useful information regarding the level to make it human usable.
+    generator_pointer: int
+        The location this level's generators are located at.
+    enemy_pointer: int
+        The location this level's enemies are located at.
+    tileset: int
+        The tileset of the this level.
+    generator_size: int
+        The amount of space the generator data takes inside the game.
+    enemy_size: int
+        The amount of space the enemy data takes inside the game.
+    """
+
+    display_information: PydanticDisplayInformation
+    generator_pointer: int
+    enemy_pointer: int
+    tileset: int
+    generator_size: int
+    enemy_size: int
+
+    def to_level(self) -> Level:
+        """
+        Converts the instance to a dataclass to be more easily modified.
+
+        Returns
+        -------
+        Level
+            The level representation of this instance.
+        """
+        return Level(
+            self.display_information.to_display_information(),
+            self.generator_pointer,
+            self.enemy_pointer,
+            self.tileset,
+            self.generator_size,
+            self.enemy_size,
+        )
+
+
+def to_pydantic_location(location: Location) -> PydanticLocation:
+    """
+    Converts a location to a pydantic location.
+
+    Parameters
+    ----------
+    location : Location
+        The location to convert.
+
+    Returns
+    -------
+    PydanticLocation
+        The pydantic equivelant of the location.
+    """
+    return PydanticLocation(world=location.world, index=location.index)
+
+
+def to_pydantic_display_information(display_information: DisplayInformation) -> PydanticDisplayInformation:
+    """
+    Converts a display information to a pydantic displayer information.
+
+    Parameters
+    ----------
+    display_information : DisplayInformation
+        The display information to convert.
+
+    Returns
+    -------
+    PydanticDisplayInformation
+        The pydantic equivelant of the display information.
+    """
+    return PydanticDisplayInformation(
+        name=display_information.name,
+        description=display_information.description,
+        locations=[to_pydantic_location(loc) for loc in display_information.locations],
+    )
+
+
+def to_pydantic_level(level: Level) -> PydanticLevel:
+    """
+    Converts a level to a pydantic level.
+
+    Parameters
+    ----------
+    level : Level
+        The level to convert.
+
+    Returns
+    -------
+    PydanticLevel
+        The pydantic equivelant of the level.
+    """
+    return PydanticLevel(
+        display_information=to_pydantic_display_information(level.display_information),
+        generator_pointer=level.generator_pointer,
+        enemy_pointer=level.enemy_pointer,
+        tileset=level.tileset,
+        generator_size=level.generator_size,
+        enemy_size=level.enemy_size,
+    )
+
+
+def generate_default_level_information() -> list[Level]:
+    """
+    Generates a default assortment of levels to be applied to a new file.
+
+    Returns
+    -------
+    list[Level]
+        A list of levels that the base game contains.
+    """
+    with open(default_levels_path, "r") as f:
+        return [PydanticLevel(**level).to_level() for level in loads(f.read())]
+
+
 def get_world_levels(world: int, levels: list[Level]) -> list[Level]:
     """
     Provides every level that is inside a given world.
@@ -75,12 +255,12 @@ def get_world_levels(world: int, levels: list[Level]) -> list[Level]:
     ----------
     world : int
         The world to select levels from.
-    levels : list[Level]
+    levels : list[PydanticLevel]
         The index of levels to find levels from.
 
     Returns
     -------
-    list[Level]
+    list[PydanticLevel]
         A sub-list of levels which contains only the levels that were inside the given world.
 
     Notes
@@ -91,17 +271,17 @@ def get_world_levels(world: int, levels: list[Level]) -> list[Level]:
     for level in levels:
         for location in level.display_information.locations:
             if location.world == world:
-                world_levels.update({location.index: level})
+                world_levels[location.index] = level
     return [element[1] for element in sorted(world_levels.items(), key=lambda item: item[0])]
 
 
-def get_worlds(levels: list[Level]) -> int:
+def get_worlds(levels: list[PydanticLevel]) -> int:
     """
     Determines the amount of worlds there are inside the game.
 
     Parameters
     ----------
-    levels : list[Level]
+    levels : list[PydanticLevel]
         The levels to find worlds from.
 
     Returns
@@ -116,6 +296,6 @@ def get_worlds(levels: list[Level]) -> int:
     return worlds
 
 
-def load_level_offsets() -> list[Level]:
+def load_level_offsets() -> list[PydanticLevel]:
     with open(data_dir.joinpath("levels.json"), "r") as f:
-        return [Level(**level) for level in loads(f.read())]
+        return [PydanticLevel(**level) for level in loads(f.read())]

--- a/foundry/gui/LevelDataEditor.py
+++ b/foundry/gui/LevelDataEditor.py
@@ -1,0 +1,587 @@
+from typing import Optional
+
+from attr import attrs, evolve, field
+from attr.validators import instance_of
+from PySide6.QtCore import Signal, SignalInstance
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QCheckBox, QComboBox, QFormLayout, QHBoxLayout, QWidget
+
+from foundry.core.UndoController import UndoController
+from foundry.core.validators import range_validator
+
+LEVEL_LENGTHS = [0x10 * (i + 1) for i in range(2**4)]
+STR_LEVEL_LENGTHS = [f"{length - 1:0=#4X} / {length} Blocks".replace("X", "x") for length in LEVEL_LENGTHS]
+
+
+MUSIC_ITEMS = [
+    "Plain level",
+    "Underground",
+    "Water level",
+    "Fortress",
+    "Boss",
+    "Ship",
+    "Battle",
+    "P-Switch/Mushroom house (1)",
+    "Hilly level",
+    "Castle room",
+    "Clouds/Sky",
+    "P-Switch/Mushroom house (2)",
+    "No music",
+    "P-Switch/Mushroom house (1)",
+    "No music",
+    "World 7 map",
+]
+
+TIMES = ["300", "400", "200", "Unlimited"]
+
+SCROLL_DIRECTIONS = [
+    "Locked, unless climbing/flying",
+    "Free vertical scrolling",
+    "Locked 'by start coordinates'?",
+    "Shouldn't appear in game, do not use.",
+]
+
+
+@attrs(slots=True, auto_attribs=True, eq=True, frozen=True, hash=True)
+class LevelDataState:
+    """
+    The representation of the start parameters for the player for a given level.
+
+    level_length: int
+        The length of the level.
+    music: int
+        The music selected for the level.
+    time: int
+        The time provided to the player to complete the level.
+    scroll: int
+        The rules applied to the scroll for the level.
+    horizontal: bool
+        If the level is horizontal.
+    pipe_ends_level: bool
+        If entering a pipe ends the level.
+    """
+
+    level_length: int = field(validator=[instance_of(int), range_validator(0, 15)])
+    music: int = field(validator=[instance_of(int), range_validator(0, 63)])
+    time: int = field(validator=[instance_of(int), range_validator(0, 3)])
+    scroll: int = field(validator=[instance_of(int), range_validator(0, 3)])
+    horizontal: bool
+    pipe_ends_level: bool
+
+
+class LevelDataEditor(QWidget):
+    """
+    A widget which controls the GUI associated with editing this level's data.
+
+    Signals
+    -------
+    level_length_changed: SignalInstance[int]
+        A signal which is activated on level length change.
+    music_changed: SignalInstance[int]
+        A signal which is activated on music change.
+    time_changed: SignalInstance[int]
+        A signal which is activated on time change.
+    scroll_changed: SignalInstance[int]
+        A signal which is activated on scroll type change.
+    horizontal_changed: SignalInstance[bool]
+        A signal which is activated on level horizontality change.
+    pipe_ends_level_changed: SignalInstance[bool]
+        A signal which is activated on if pipe ends level change.
+    state_changed: SignalInstance[LevelDataState]
+        A signal which is activated on any state change.
+
+    Attributes
+    ----------
+    undo_controller: UndoController[LevelDataState]
+        The undo controller, which is responsible for undoing and redoing any action.
+    """
+
+    level_length_changed: SignalInstance = Signal(int)  # type: ignore
+    music_changed: SignalInstance = Signal(int)  # type: ignore
+    time_changed: SignalInstance = Signal(int)  # type: ignore
+    scroll_changed: SignalInstance = Signal(int)  # type: ignore
+    horizontal_changed: SignalInstance = Signal(bool)  # type: ignore
+    pipe_ends_level_changed: SignalInstance = Signal(bool)  # type: ignore
+    state_changed: SignalInstance = Signal(object)  # type: ignore
+
+    undo_controller: UndoController[LevelDataState]
+
+    def __init__(
+        self,
+        parent: Optional[QWidget],
+        state: LevelDataState,
+        undo_controller: Optional[UndoController[LevelDataState]] = None,
+    ):
+        super().__init__(parent)
+        self._state = state
+        self.undo_controller = undo_controller or UndoController(self.state)
+
+        # Set up the display
+        self._display = LevelDataDisplay(
+            self, self.level_length, self.music, self.time, self.scroll, self.horizontal, self.pipe_ends_level
+        )
+
+        # Connect signals accordingly
+        self._display.level_length_editor.currentIndexChanged.connect(  # type: ignore
+            lambda *_: self._level_length_update()
+        )
+        self._display.music_editor.currentIndexChanged.connect(lambda *_: self._music_update())  # type: ignore
+        self._display.time_editor.currentIndexChanged.connect(lambda *_: self._time_update())  # type: ignore
+        self._display.scroll_editor.currentIndexChanged.connect(lambda *_: self._scroll_update())  # type: ignore
+        self._display.horizontal_editor.stateChanged.connect(lambda *_: self._horizontal_update())  # type: ignore
+        self._display.pipe_ends_level_editor.stateChanged.connect(  # type: ignore
+            lambda *_: self._pipe_ends_level_update()
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.parent}, {self.state}, {self.undo_controller})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelDataEditor)
+            and self.state == other.state
+            and self.undo_controller == other.undo_controller
+        )
+
+    @property
+    def level_length(self) -> int:
+        """
+        Provides the length of the level.
+
+        Returns
+        -------
+        int
+            The length of the level.
+        """
+        return self.state.level_length
+
+    @level_length.setter
+    def level_length(self, level_length: int):
+        if self.level_length != level_length:
+            self.do(evolve(self.state, level_length=level_length))
+
+    @property
+    def music(self) -> int:
+        """
+        Provides the music of the level.
+
+        Returns
+        -------
+        int
+            The music of the level.
+        """
+        return self.state.music
+
+    @music.setter
+    def music(self, music: int):
+        if self.music != music:
+            self.do(evolve(self.state, music=music))
+
+    @property
+    def time(self) -> int:
+        """
+        Provides the time of the level.
+
+        Returns
+        -------
+        int
+            The time of the level.
+        """
+        return self.state.time
+
+    @time.setter
+    def time(self, time: int):
+        if self.time != time:
+            self.do(evolve(self.state, time=time))
+
+    @property
+    def scroll(self) -> int:
+        """
+        Provides the scroll of the level.
+
+        Returns
+        -------
+        int
+            The scroll of the level.
+        """
+        return self.state.scroll
+
+    @scroll.setter
+    def scroll(self, scroll: int):
+        if self.scroll != scroll:
+            self.do(evolve(self.state, scroll=scroll))
+
+    @property
+    def horizontal(self) -> bool:
+        """
+        Provides if the level is horizontal.
+
+        Returns
+        -------
+        bool
+            If the level is horizontal.
+        """
+        return self.state.horizontal
+
+    @horizontal.setter
+    def horizontal(self, horizontal: bool):
+        if self.horizontal != horizontal:
+            self.do(evolve(self.state, horizontal=horizontal))
+
+    @property
+    def pipe_ends_level(self) -> bool:
+        """
+        Provides if entering a pipe will end the level.
+
+        Returns
+        -------
+        bool
+            If the entering pipes end the level.
+        """
+        return self.state.pipe_ends_level
+
+    @pipe_ends_level.setter
+    def pipe_ends_level(self, pipe_ends_level: bool):
+        if self.pipe_ends_level != pipe_ends_level:
+            self.do(evolve(self.state, pipe_ends_level=pipe_ends_level))
+
+    @property
+    def state(self) -> LevelDataState:
+        """
+        Provides the current state of the instance.
+
+        Returns
+        -------
+        LevelDataState
+            A tuple of the level length, music, time, scroll, and other data associated with the current
+            instance's level.
+        """
+        return self._state
+
+    @state.setter
+    def state(self, state: LevelDataState):
+        if self.state != state:
+            self.do(state)
+
+    def do(self, new_state: LevelDataState) -> LevelDataState:
+        """
+        Does an action through the controller, adding it to the undo stack and clearing the redo
+        stack, respectively.
+
+        Parameters
+        ----------
+        new_state : LevelDataState
+            The new state to be stored.
+
+        Returns
+        -------
+        LevelDataState
+            The new state that has been stored.
+        """
+        self._update_state(new_state)
+        return self.undo_controller.do(new_state)
+
+    @property
+    def can_undo(self) -> bool:
+        """
+        Determines if there is any states inside the undo stack.
+
+        Returns
+        -------
+        bool
+            If there is an undo state available.
+        """
+        return self.undo_controller.can_undo
+
+    def undo(self) -> LevelDataState:
+        """
+        Undoes the last state, bring the previous.
+
+        Returns
+        -------
+        LevelDataState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.undo())
+        return self.state
+
+    @property
+    def can_redo(self) -> bool:
+        """
+        Determines if there is any states inside the redo stack.
+
+        Returns
+        -------
+        bool
+            If there is an redo state available.
+        """
+        return self.undo_controller.can_redo
+
+    def redo(self) -> LevelDataState:
+        """
+        Redoes the previously undone state.
+
+        Returns
+        -------
+        LevelDataState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.redo())
+        return self.state
+
+    def _update_state(self, state: LevelDataState):
+        """
+        Handles all updating of the state, sending any signals and updates to the display if needed.
+
+        Parameters
+        ----------
+        state : LevelDataState
+            The new state of the editor.
+        """
+
+        if self.undo_controller.state.level_length != state.level_length or self.level_length != state.level_length:
+            self.level_length_changed.emit(state.level_length)
+            self._state = evolve(self.state, level_length=state.level_length)
+            self._display.level_length = state.level_length
+
+        if self.undo_controller.state.music != state.music or self.music != state.music:
+            self.music_changed.emit(state.music)
+            self._state = evolve(self.state, music=state.music)
+            self._display.music = state.music
+
+        if self.undo_controller.state.time != state.time or self.time != state.time:
+            self.time_changed.emit(state.time)
+            self._state = evolve(self.state, time=state.time)
+            self._display.time = state.time
+
+        if self.undo_controller.state.scroll != state.scroll or self.scroll != state.scroll:
+            self.scroll_changed.emit(state.scroll)
+            self._state = evolve(self.state, scroll=state.scroll)
+            self._display.scroll = state.scroll
+
+        if self.undo_controller.state.horizontal != state.horizontal or self.horizontal != state.horizontal:
+            self.horizontal_changed.emit(state.horizontal)
+            self._state = evolve(self.state, horizontal=state.horizontal)
+            self._display.horizontal = state.horizontal
+
+        if (
+            self.undo_controller.state.pipe_ends_level != state.pipe_ends_level
+            or self.pipe_ends_level != state.pipe_ends_level
+        ):
+            self.pipe_ends_level_changed.emit(state.pipe_ends_level)
+            self._state = evolve(self.state, pipe_ends_level=state.pipe_ends_level)
+            self._display.pipe_ends_level = state.pipe_ends_level
+
+        self.state_changed.emit(state)
+
+    # Updates from display
+
+    def _level_length_update(self):
+        self.level_length = self._display.level_length
+
+    def _music_update(self):
+        self.music = self._display.music
+
+    def _time_update(self):
+        self.time = self._display.time
+
+    def _scroll_update(self):
+        self.scroll = self._display.scroll
+
+    def _horizontal_update(self):
+        self.horizontal = self._display.horizontal
+
+    def _pipe_ends_level_update(self):
+        self.pipe_ends_level = self._display.pipe_ends_level
+
+
+class LevelDataDisplay(QFormLayout):
+    """
+    The active display for the level data editor.
+
+    Attributes
+    ----------
+    level_length_editor: QComboBox
+        The editor for this level's length.
+    music_editor: QComboBox
+        The editor for this level's music.
+    time_editor: QComboBox
+        The editor for this level's time.
+    scroll_editor: QComboBox
+        The editor for this level's scroll.
+    horizontal_editor: QCheckBox
+        The editor to determine if this level is horizontal or vertical.
+    pipe_ends_level_editor: QCheckBox
+        The editor to determine if entering a pipe will end the level.
+    """
+
+    level_length_editor: QComboBox
+    music_editor: QComboBox
+    time_editor: QComboBox
+    scroll_editor: QComboBox
+    horizontal_editor: QCheckBox
+    pipe_ends_level_editor: QCheckBox
+
+    def __init__(
+        self,
+        parent: Optional[QWidget],
+        level_length: int,
+        music: int,
+        time: int,
+        scroll: int,
+        horizontal: bool,
+        pipe_ends_level: bool,
+    ):
+        super().__init__(parent)
+
+        self.setFormAlignment(Qt.AlignCenter)  # type: ignore
+
+        self.level_length_editor = QComboBox()
+        self.level_length_editor.addItems(STR_LEVEL_LENGTHS[:-1] if horizontal else STR_LEVEL_LENGTHS)
+
+        self.music_editor = QComboBox()
+        self.music_editor.addItems(MUSIC_ITEMS)
+
+        self.time_editor = QComboBox()
+        self.time_editor.addItems(TIMES)
+
+        self.scroll_editor = QComboBox()
+        self.scroll_editor.addItems(SCROLL_DIRECTIONS)
+
+        self.horizontal_editor = QCheckBox("Level is Horizontal")
+        self.pipe_ends_level_editor = QCheckBox("Pipe ends Level")
+
+        check_box_layout = QHBoxLayout()
+        check_box_layout.setContentsMargins(0, 0, 0, 0)
+        check_box_layout.addWidget(self.horizontal_editor)
+        check_box_layout.addWidget(self.pipe_ends_level_editor)
+
+        check_box_widget = QWidget()
+        check_box_widget.setLayout(check_box_layout)
+
+        self.level_length = level_length
+        self.music = music
+        self.time = time
+        self.scroll = scroll
+        self.horizontal = horizontal
+        self.pipe_ends_level = pipe_ends_level
+
+        self.addRow("Level Length: ", self.level_length_editor)
+        self.addRow("Music: ", self.music_editor)
+        self.addRow("Time: ", self.time_editor)
+        self.addRow("Scroll Direction: ", self.scroll_editor)
+        self.addWidget(check_box_widget)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            + f"{self.parent}, {self.level_length}, {self.music}, {self.time}, "
+            + f"{self.scroll}, {self.horizontal}, {self.pipe_ends_level})"
+        )
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelDataDisplay)
+            and self.level_length == other.level_length
+            and self.music == other.music
+            and self.time == other.time
+            and self.scroll == other.scroll
+            and self.horizontal == other.horizontal
+            and self.pipe_ends_level == other.pipe_ends_level
+        )
+
+    @property
+    def level_length(self) -> int:
+        """
+        Provides the length of this level.
+
+        Returns
+        -------
+        int
+            The length of this level.
+        """
+        return self.level_length_editor.currentIndex()
+
+    @level_length.setter
+    def level_length(self, level_length: int):
+        self.level_length_editor.setCurrentIndex(level_length)
+
+    @property
+    def music(self) -> int:
+        """
+        Provides the music of this level.
+
+        Returns
+        -------
+        int
+            The music of this level.
+        """
+        return self.music_editor.currentIndex()
+
+    @music.setter
+    def music(self, music: int):
+        self.music_editor.setCurrentIndex(music)
+
+    @property
+    def time(self) -> int:
+        """
+        Provides the time of this level.
+
+        Returns
+        -------
+        int
+            The time of this level.
+        """
+        return self.time_editor.currentIndex()
+
+    @time.setter
+    def time(self, time: int):
+        self.time_editor.setCurrentIndex(time)
+
+    @property
+    def scroll(self) -> int:
+        """
+        Provides the scroll of this level.
+
+        Returns
+        -------
+        int
+            The scroll of this level.
+        """
+        return self.scroll_editor.currentIndex()
+
+    @scroll.setter
+    def scroll(self, scroll: int):
+        self.scroll_editor.setCurrentIndex(scroll)
+
+    @property
+    def horizontal(self) -> bool:
+        """
+        Provides if the level is horizontal.
+
+        Returns
+        -------
+        bool
+            If the level is horizontal.
+        """
+        return self.horizontal_editor.isChecked()
+
+    @horizontal.setter
+    def horizontal(self, horizontal: bool):
+        self.horizontal_editor.setChecked(horizontal)
+
+    @property
+    def pipe_ends_level(self) -> bool:
+        """
+        Provides if entering a pipe will end the level.
+
+        Returns
+        -------
+        bool
+            If entering a pipe will end the level.
+        """
+        return self.pipe_ends_level_editor.isChecked()
+
+    @pipe_ends_level.setter
+    def pipe_ends_level(self, pipe_ends_level: bool):
+        self.pipe_ends_level_editor.setChecked(pipe_ends_level)

--- a/foundry/gui/LevelDrawer.py
+++ b/foundry/gui/LevelDrawer.py
@@ -25,7 +25,7 @@ from foundry.game.gfx.objects.ObjectLike import (
 )
 from foundry.game.level.Level import Level
 from foundry.gui.AutoScrollDrawer import AutoScrollDrawer
-from foundry.gui.settings import SETTINGS
+from foundry.gui.settings import UserSettings
 from foundry.smb3parse.constants import OBJ_AUTOSCROLL, TILESET_BACKGROUND_BLOCKS
 from foundry.smb3parse.levels import LEVEL_MAX_LENGTH
 from foundry.smb3parse.objects.object_set import (
@@ -116,16 +116,8 @@ def _block_from_index(block_index: int, level: Level) -> Block:
 
 
 class LevelDrawer:
-    def __init__(self):
-        self.draw_jumps = False
-        self.draw_grid = False
-        self.draw_expansions = False
-        self.draw_mario = False
-        self.draw_jumps_on_objects = True
-        self.draw_items_in_blocks = True
-        self.draw_invisible_items = True
-        self.draw_autoscroll = True
-        self.transparency = False
+    def __init__(self, user_settings: UserSettings):
+        self.user_settings = user_settings
 
         self.block_length = Block.WIDTH
 
@@ -150,19 +142,19 @@ class LevelDrawer:
 
         self._draw_overlays(painter, level)
 
-        if self.draw_expansions:
+        if self.user_settings.draw_expansion:
             self._draw_expansions(painter, level)
 
-        if self.draw_mario:
+        if self.user_settings.draw_mario:
             self._draw_mario(painter, level)
 
-        if self.draw_jumps:
+        if self.user_settings.draw_jumps:
             self._draw_jumps(painter, level)
 
-        if self.draw_grid:
+        if self.user_settings.draw_grid:
             self._draw_grid(painter, level)
 
-        if self.draw_autoscroll:
+        if self.user_settings.draw_autoscroll:
             self._draw_auto_scroll(painter, level)
 
     def _draw_background(self, painter: QPainter, level: Level):
@@ -261,9 +253,9 @@ class LevelDrawer:
                     level_object._draw_block(painter, block_index, x, y, self.block_length, False, blocks=blocks)
             else:
                 if isinstance(level_object, LevelObject):
-                    level_object.draw(painter, self.block_length, self.transparency, blocks=blocks)
+                    level_object.draw(painter, self.block_length, self.user_settings.block_transparency, blocks=blocks)
                 else:
-                    level_object.draw(painter, self.block_length, self.transparency)
+                    level_object.draw(painter, self.block_length, self.user_settings.block_transparency)
 
             if level_object.selected:
                 painter.save()
@@ -294,7 +286,7 @@ class LevelDrawer:
 
             # pipe entries
             if "pipe" in name and "can go" in name:
-                if not self.draw_jumps_on_objects:
+                if not self.user_settings.draw_jump_on_objects:
                     continue
 
                 fill_object = False
@@ -357,7 +349,7 @@ class LevelDrawer:
 
             # "?" - blocks, note blocks, wooden blocks and bricks
             elif "'?' with" in name or "brick with" in name or "bricks with" in name or "block with" in name:
-                if not self.draw_items_in_blocks:
+                if not self.user_settings.draw_items_in_blocks:
                     continue
 
                 pos.setY(pos.y() - self.block_length)
@@ -389,7 +381,7 @@ class LevelDrawer:
                 painter.drawImage(arrow_pos, ITEM_ARROW.scaled(self.block_length, self.block_length))
 
             elif "invisible" in name:
-                if not self.draw_invisible_items:
+                if not self.user_settings.draw_invisible_items:
                     continue
 
                 if "coin" in name:
@@ -400,7 +392,7 @@ class LevelDrawer:
                     image = EMPTY_IMAGE
 
             elif "silver coins" in name:
-                if not self.draw_invisible_items:
+                if not self.user_settings.draw_invisible_items:
                     continue
 
                 image = SILVER_COIN
@@ -439,7 +431,7 @@ class LevelDrawer:
             if level_object.selected:
                 painter.drawRect(level_object.get_rect(self.block_length))
 
-            if self.draw_expansions:
+            if self.user_settings.draw_expansion:
                 painter.save()
 
                 painter.setPen(Qt.NoPen)
@@ -464,7 +456,7 @@ class LevelDrawer:
 
         x_offset = 32 * level.start_action
         MARIO_POWERUP_Y_OFFSETS = [0, 0x20, 0x60, 0x40, 0xC0, 0xA0, 0x80, 0x60, 0xC0]
-        y_offset = MARIO_POWERUP_Y_OFFSETS[SETTINGS["default_powerup"]]
+        y_offset = MARIO_POWERUP_Y_OFFSETS[self.user_settings.default_powerup]
 
         mario_cutout = mario_actions.copy(QRect(x_offset, y_offset, 32, 32)).scaled(
             2 * self.block_length, 2 * self.block_length

--- a/foundry/gui/LevelGraphicsEditor.py
+++ b/foundry/gui/LevelGraphicsEditor.py
@@ -1,0 +1,371 @@
+from typing import Optional
+
+from attr import attrs, field
+from attr.validators import instance_of
+from PySide6.QtCore import Signal, SignalInstance
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QComboBox, QFormLayout, QWidget
+
+from foundry.core.graphics_set.util import GRAPHIC_SET_NAMES
+from foundry.core.UndoController import UndoController
+from foundry.core.validators import range_validator
+from foundry.gui.Spinner import Spinner
+
+
+@attrs(slots=True, auto_attribs=True, eq=True, frozen=True, hash=True)
+class LevelGraphicsState:
+    """
+    for this level for a level to warp to.
+
+    generator_palette: int
+        The generator palette for for this level.
+    enemy_palette: int
+        The enemy palette for for this level.
+    graphics_set: int
+        The graphics_set for for this level.
+    """
+
+    generator_palette: int = field(validator=[instance_of(int), range_validator(0, 7)])
+    enemy_palette: int = field(validator=[instance_of(int), range_validator(0, 3)])
+    graphics_set: int = field(validator=[instance_of(int), range_validator(0, 31)])
+
+
+class LevelGraphicsEditor(QWidget):
+    """
+    A widget which controls the GUI associated with editing graphics of this level.
+
+    Signals
+    -------
+    generator_palette_changed: SignalInstance[int]
+        A signal which is activated on generator palette change.
+    enemy_palette_changed: SignalInstance[int]
+        A signal which is activated on enemy palette change.
+    graphics_set_changed: SignalInstance[int]
+        A signal which is activated on graphics set change.
+    state_changed: SignalInstance[LevelGraphicsState]
+        A signal which is activated on any state change.
+
+    Attributes
+    ----------
+    level: LevelGraphicsState
+        The model of current graphics.
+    undo_controller: UndoController[LevelGraphicsState]
+        The undo controller, which is responsible for undoing and redoing any action.
+    """
+
+    generator_palette_changed: SignalInstance = Signal(int)  # type: ignore
+    enemy_palette_changed: SignalInstance = Signal(int)  # type: ignore
+    graphics_set_changed: SignalInstance = Signal(int)  # type: ignore
+    state_changed: SignalInstance = Signal(object)  # type: ignore
+
+    undo_controller: UndoController[LevelGraphicsState]
+
+    def __init__(
+        self,
+        parent: Optional[QWidget],
+        state: LevelGraphicsState,
+        undo_controller: Optional[UndoController[LevelGraphicsState]] = None,
+    ):
+        super().__init__(parent)
+        self._state = state
+        self.undo_controller = undo_controller or UndoController(self.state)
+
+        # Set up the display
+        self._display = LevelGraphicsDisplay(self, self.generator_palette, self.enemy_palette, self.graphics_set)
+
+        # Connect signals accordingly
+        self._display.generator_palette_editor.valueChanged.connect(  # type: ignore
+            lambda *_: self._generator_palette_update()
+        )
+        self._display.enemy_palette_editor.valueChanged.connect(lambda *_: self._enemy_palette_update())  # type: ignore
+        self._display.graphics_set_editor.currentIndexChanged.connect(  # type: ignore
+            lambda *_: self._graphics_set_update()
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.parent}, {self.state}, {self.undo_controller})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelGraphicsEditor)
+            and self.state == other.state
+            and self.undo_controller == other.undo_controller
+        )
+
+    @property
+    def generator_palette(self) -> int:
+        """
+        Provides the generator palette of this level.
+
+        Returns
+        -------
+        int
+            The generator palette of for this level.
+        """
+        return self.state.generator_palette
+
+    @generator_palette.setter
+    def generator_palette(self, generator_palette: int):
+        if self.generator_palette != generator_palette:
+            self.do(LevelGraphicsState(generator_palette, self.enemy_palette, self.graphics_set))
+
+    @property
+    def enemy_palette(self) -> int:
+        """
+        Provides the enemy palette of this level.
+
+        Returns
+        -------
+        int
+            The enemy palette of for this level.
+        """
+        return self.state.enemy_palette
+
+    @enemy_palette.setter
+    def enemy_palette(self, enemy_palette: int):
+        if self.enemy_palette != enemy_palette:
+            self.do(LevelGraphicsState(self.generator_palette, enemy_palette, self.graphics_set))
+
+    @property
+    def graphics_set(self) -> int:
+        """
+        Provides the graphics set of this level.
+
+        Returns
+        -------
+        int
+            The graphics set of for this level.
+        """
+        return self.state.graphics_set
+
+    @graphics_set.setter
+    def graphics_set(self, graphics_set: int):
+        if self.graphics_set != graphics_set:
+            self.do(LevelGraphicsState(self.generator_palette, self.enemy_palette, graphics_set))
+
+    @property
+    def state(self) -> LevelGraphicsState:
+        """
+        Provides the current state of the instance.
+
+        Returns
+        -------
+        LevelGraphicsState
+            A tuple of the name, description, generator size, and enemy size for the current instance's level.
+        """
+        return self._state
+
+    @state.setter
+    def state(self, state: LevelGraphicsState):
+        if self.state != state:
+            self.do(state)
+
+    def do(self, new_state: LevelGraphicsState) -> LevelGraphicsState:
+        """
+        Does an action through the controller, adding it to the undo stack and clearing the redo
+        stack, respectively.
+
+        Parameters
+        ----------
+        new_state : LevelGraphicsState
+            The new state to be stored.
+
+        Returns
+        -------
+        LevelGraphicsState
+            The new state that has been stored.
+        """
+        self._update_state(new_state)
+        return self.undo_controller.do(new_state)
+
+    @property
+    def can_undo(self) -> bool:
+        """
+        Determines if there is any states inside the undo stack.
+
+        Returns
+        -------
+        bool
+            If there is an undo state available.
+        """
+        return self.undo_controller.can_undo
+
+    def undo(self) -> LevelGraphicsState:
+        """
+        Undoes the last state, bring the previous.
+
+        Returns
+        -------
+        LevelGraphicsState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.undo())
+        return self.state
+
+    @property
+    def can_redo(self) -> bool:
+        """
+        Determines if there is any states inside the redo stack.
+
+        Returns
+        -------
+        bool
+            If there is an redo state available.
+        """
+        return self.undo_controller.can_redo
+
+    def redo(self) -> LevelGraphicsState:
+        """
+        Redoes the previously undone state.
+
+        Returns
+        -------
+        LevelGraphicsState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.redo())
+        return self.state
+
+    def _update_state(self, state: LevelGraphicsState):
+        """
+        Handles all updating of the state, sending any signals and updates to the display if needed.
+
+        Parameters
+        ----------
+        state : LevelGraphicsState
+            The new state of the editor.
+        """
+
+        generator_palette = state.generator_palette
+        enemy_palette = state.enemy_palette
+        graphics_set = state.graphics_set
+
+        if (
+            self.undo_controller.state.generator_palette != generator_palette
+            or self.generator_palette != generator_palette
+        ):
+            self.generator_palette_changed.emit(generator_palette)
+            self._state = LevelGraphicsState(state.generator_palette, self.enemy_palette, self.graphics_set)
+            self._display.generator_palette = generator_palette
+
+        if self.undo_controller.state.enemy_palette != enemy_palette or self.enemy_palette != enemy_palette:
+            self.enemy_palette_changed.emit(enemy_palette)
+            self._state = LevelGraphicsState(self.generator_palette, state.enemy_palette, self.graphics_set)
+            self._display.enemy_palette = enemy_palette
+
+        if self.undo_controller.state.graphics_set != graphics_set or self.graphics_set != graphics_set:
+            self.graphics_set_changed.emit(graphics_set)
+            self._state = LevelGraphicsState(self.generator_palette, self.enemy_palette, state.graphics_set)
+            self._display.graphics_set = graphics_set
+
+        self.state_changed.emit(state)
+
+    # Updates from display
+
+    def _generator_palette_update(self):
+        self.generator_palette = self._display.generator_palette
+
+    def _enemy_palette_update(self):
+        self.enemy_palette = self._display.enemy_palette
+
+    def _graphics_set_update(self):
+        self.graphics_set = self._display.graphics_set
+
+
+class LevelGraphicsDisplay(QFormLayout):
+    """
+    The active display for the level warp editor.
+
+    Attributes
+    ----------
+    generator_palette_editor: Spinner
+        The editor for this level's generator palette.
+    enemy_palette_editor: Spinner
+        The editor for this level's enemy palette.
+    graphics_set_editor: QComboBox
+        The editor for this level's graphics set.
+    """
+
+    generator_palette_editor: Spinner
+    enemy_palette_editor: Spinner
+    graphics_set_editor: QComboBox
+
+    def __init__(self, parent: Optional[QWidget], generator_palette: int, enemy_palette: int, graphics_set: int):
+        super().__init__(parent)
+
+        self.setFormAlignment(Qt.AlignCenter)  # type: ignore
+
+        self.generator_palette_editor = Spinner(None, maximum=7)
+        self.enemy_palette_editor = Spinner(None, maximum=3)
+        self.graphics_set_editor = QComboBox()
+        self.graphics_set_editor.addItems(GRAPHIC_SET_NAMES)
+
+        self.generator_palette = generator_palette
+        self.enemy_palette = enemy_palette
+        self.graphics_set = graphics_set
+
+        self.addRow("Generator Palette: ", self.generator_palette_editor)
+        self.addRow("Enemy Palette: ", self.enemy_palette_editor)
+        self.addRow("Graphic Set: ", self.graphics_set_editor)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            + f"{self.parent}, {self.generator_palette}, {self.enemy_palette}, {self.graphics_set})"
+        )
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelGraphicsDisplay)
+            and self.generator_palette == other.generator_palette
+            and self.enemy_palette == other.enemy_palette
+            and self.graphics_set == other.graphics_set
+        )
+
+    @property
+    def generator_palette(self) -> int:
+        """
+        Provides the generator palette of this level.
+
+        Returns
+        -------
+        int
+            The generator palette of for this level.
+        """
+        return self.generator_palette_editor.value()
+
+    @generator_palette.setter
+    def generator_palette(self, generator_palette: int):
+        self.generator_palette_editor.setValue(generator_palette)
+
+    @property
+    def enemy_palette(self) -> int:
+        """
+        Provides the enemy palette of this level.
+
+        Returns
+        -------
+        int
+            The enemy palette of for this level.
+        """
+        return self.enemy_palette_editor.value()
+
+    @enemy_palette.setter
+    def enemy_palette(self, enemy_palette: int):
+        self.enemy_palette_editor.setValue(enemy_palette)
+
+    @property
+    def graphics_set(self) -> int:
+        """
+        Provides the graphics_set of this level.
+
+        Returns
+        -------
+        int
+            The graphics_set of for this level.
+        """
+        return self.graphics_set_editor.currentIndex()
+
+    @graphics_set.setter
+    def graphics_set(self, graphics_set: int):
+        self.graphics_set_editor.setCurrentIndex(graphics_set)

--- a/foundry/gui/LevelInformationEditor.py
+++ b/foundry/gui/LevelInformationEditor.py
@@ -1,0 +1,420 @@
+from typing import Optional, Union
+
+from attr import evolve
+from PySide6.QtCore import Signal, SignalInstance
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QFormLayout, QLineEdit, QSpinBox, QWidget
+
+from foundry.core.UndoController import UndoController
+from foundry.game.level.util import Level as LevelData
+
+LevelDataState = tuple[str, str, int, int]
+
+
+class LevelInformationEditor(QWidget):
+    """
+    A widget which controls the GUI associated with editing information for a given level.
+
+    Signals
+    -------
+    name_changed: SignalInstance[str]
+        A signal which is activated on name change.
+    description_changed: SignalInstance[str]
+        A signal which is activated on description change.
+    generator_space_changed: SignalInstance[int]
+        A signal which is activated on generation space change.
+    enemy_space_changed: SignalInstance[int]
+        A signal which is activated on enemy space change.
+    state_changed: SignalInstance[LevelDataState]
+        A signal which is activated on any state change.
+
+    Attributes
+    ----------
+    level: LevelData
+        The model of current level information.
+    undo_controller: UndoController[LevelDataState]
+        The undo controller, which is responsible for undoing and redoing any action.
+    """
+
+    name_changed: SignalInstance = Signal(str)  # type: ignore
+    description_changed: SignalInstance = Signal(str)  # type: ignore
+    generator_space_changed: SignalInstance = Signal(int)  # type: ignore
+    enemy_space_changed: SignalInstance = Signal(int)  # type: ignore
+    state_changed: SignalInstance = Signal(object)  # type: ignore
+
+    level: LevelData
+    undo_controller: UndoController[LevelDataState]
+
+    def __init__(
+        self,
+        parent: Optional[QWidget],
+        level: LevelData,
+        undo_controller: Optional[UndoController[LevelDataState]] = None,
+    ):
+        super().__init__(parent)
+        self.level = level
+        self.undo_controller = undo_controller or UndoController(self.state)
+
+        # Set up the display
+        self._display = LevelInformationEditorDisplay(
+            self, self.name, self.description, self.generator_space, self.enemy_space
+        )
+
+        # Connect signals accordingly
+        self._display.name_editor.textChanged.connect(lambda *_: self._name_update())  # type: ignore
+        self._display.description_editor.textChanged.connect(lambda *_: self._description_update())  # type: ignore
+        self._display.generator_space_editor.valueChanged.connect(  # type: ignore
+            lambda *_: self._generator_space_update()
+        )
+        self._display.enemy_space_editor.valueChanged.connect(lambda *_: self._enemy_space_update())  # type: ignore
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.parent}, {self.level}, {self.undo_controller})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelInformationEditor)
+            and self.level == other.level
+            and self.undo_controller == other.undo_controller
+        )
+
+    @property
+    def name(self) -> str:
+        """
+        Provides the name of the level.
+
+        Returns
+        -------
+        str
+            The name of the level.
+        """
+        return self.level.display_information.name or ""
+
+    @name.setter
+    def name(self, name: str):
+        if self.name != name:
+            self.level = evolve(self.level, display_information=evolve(self.level.display_information, name=name))
+            self.do(self.state)
+
+    @property
+    def description(self) -> str:
+        """
+        Provides the description of the level.
+
+        Returns
+        -------
+        str
+            The description of the level.
+        """
+        return self.level.display_information.description or ""
+
+    @description.setter
+    def description(self, description: str):
+        if self.description != description:
+            self.level = evolve(
+                self.level, display_information=evolve(self.level.display_information, description=description)
+            )
+            self.do(self.state)
+
+    @property
+    def generator_space(self) -> int:
+        """
+        Provides the space for generators inside of the level.
+
+        Returns
+        -------
+        int
+            The space for generators inside of the level.
+        """
+        return self.level.generator_size
+
+    @generator_space.setter
+    def generator_space(self, generator_space: int):
+        if self.generator_space != generator_space:
+            self.level = evolve(self.level, generator_size=generator_space)
+            self.do(self.state)
+
+    @property
+    def enemy_space(self) -> int:
+        """
+        Provides the space for enemies inside of the level.
+
+        Returns
+        -------
+        int
+            The space for enemies inside of the level.
+        """
+        return self.level.enemy_size
+
+    @enemy_space.setter
+    def enemy_space(self, enemy_space: int):
+        if self.level.enemy_size != enemy_space:
+            self.level = evolve(self.level, enemy_size=enemy_space)
+            self.do(self.state)
+
+    @property
+    def state(self) -> LevelDataState:
+        """
+        Provides the current state of the instance.
+
+        Returns
+        -------
+        LevelDataState
+            A tuple of the name, description, generator size, and enemy size for the current instance's level.
+        """
+        return (self.name, self.description, self.generator_space, self.enemy_space)
+
+    @state.setter
+    def state(self, state: Union[LevelDataState, LevelData]):
+        # Convert it to a level data state
+        if isinstance(state, LevelData):
+            state = (
+                state.display_information.name or "",
+                state.display_information.description or "",
+                state.generator_size,
+                state.enemy_size,
+            )
+        if self.state != state:
+            self._update_state(state)
+            self.do(state)
+
+    def do(self, new_state: LevelDataState) -> LevelDataState:
+        """
+        Does an action through the controller, adding it to the undo stack and clearing the redo
+        stack, respectively.
+
+        Parameters
+        ----------
+        new_state : LevelDataState
+            The new state to be stored.
+
+        Returns
+        -------
+        LevelDataState
+            The new state that has been stored.
+        """
+        self._update_state(new_state)
+        return self.undo_controller.do(new_state)
+
+    @property
+    def can_undo(self) -> bool:
+        """
+        Determines if there is any states inside the undo stack.
+
+        Returns
+        -------
+        bool
+            If there is an undo state available.
+        """
+        return self.undo_controller.can_undo
+
+    def undo(self) -> LevelDataState:
+        """
+        Undoes the last state, bring the previous.
+
+        Returns
+        -------
+        LevelDataState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.undo())
+        return self.state
+
+    @property
+    def can_redo(self) -> bool:
+        """
+        Determines if there is any states inside the redo stack.
+
+        Returns
+        -------
+        bool
+            If there is an redo state available.
+        """
+        return self.undo_controller.can_redo
+
+    def redo(self) -> LevelDataState:
+        """
+        Redoes the previously undone state.
+
+        Returns
+        -------
+        LevelDataState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.redo())
+        return self.state
+
+    def _update_state(self, state: LevelDataState):
+        """
+        Handles all updating of the state, sending any signals and updates to the display if needed.
+
+        Parameters
+        ----------
+        state : LevelDataState
+            The new state of the editor.
+        """
+
+        name, desc, gen_space, enemy_space = state
+
+        if self.undo_controller.state[0] != name or self.name != name:
+            self.name_changed.emit(name)
+            self.level = evolve(self.level, display_information=evolve(self.level.display_information, name=name))
+            self._display.name = name
+
+        if self.undo_controller.state[1] != desc or self.description != desc:
+            self.description_changed.emit(desc)
+            self.level = evolve(
+                self.level, display_information=evolve(self.level.display_information, description=desc)
+            )
+            self._display.description = desc
+
+        if self.undo_controller.state[2] != gen_space or self.generator_space != gen_space:
+            self.generator_space_changed.emit(gen_space)
+            self.level = evolve(self.level, generator_size=gen_space)
+            self._display.generator_space = gen_space
+
+        if self.undo_controller.state[3] != enemy_space or self.enemy_space != enemy_space:
+            self.enemy_space_changed.emit(enemy_space)
+            self.level = evolve(self.level, enemy_size=enemy_space)
+            self._display.enemy_space = enemy_space
+
+        self.state_changed.emit(state)
+
+    # Updates from display
+
+    def _name_update(self):
+        self.name = self._display.name
+
+    def _description_update(self):
+        self.description = self._display.description
+
+    def _generator_space_update(self):
+        self.generator_space = self._display.generator_space
+
+    def _enemy_space_update(self):
+        self.enemy_space = self._display.enemy_space
+
+
+class LevelInformationEditorDisplay(QFormLayout):
+    """
+    The active display for the level information editor.
+
+    Attributes
+    ----------
+    name_editor: QLineEdit
+        The editor for the level's name.
+    description_editor: QLineEdit
+        The editor for the level's description.
+    generator_space_editor: QSpinBox
+        The editor for the amount of space provided to the level's generators.
+    enemy_space_editor: QSpinBox
+        The editor for the amount of space provided to the level's enemies.
+    """
+
+    name_editor: QLineEdit
+    description_editor: QLineEdit
+    generator_space_editor: QSpinBox
+    enemy_space_editor: QSpinBox
+
+    def __init__(self, parent: Optional[QWidget], name: str, description: str, generator_space: int, enemy_space: int):
+        super().__init__(parent)
+
+        self.setFormAlignment(Qt.AlignCenter)  # type: ignore
+
+        self.name_editor = QLineEdit(name)
+
+        self.description_editor = QLineEdit(description)
+
+        self.generator_space_editor = QSpinBox()
+        self.generator_space_editor.setMinimum(0)
+        self.generator_space_editor.setMaximum(0x2000)
+        self.generator_space_editor.setValue(generator_space)
+
+        self.enemy_space_editor = QSpinBox()
+        self.enemy_space_editor.setMinimum(0)
+        self.enemy_space_editor.setMaximum(0x2000)
+        self.enemy_space_editor.setValue(enemy_space)
+
+        self.addRow("Name: ", self.name_editor)
+        self.addRow("Description: ", self.description_editor)
+        self.addRow("Generator Space: ", self.generator_space_editor)
+        self.addRow("Enemy Space: ", self.enemy_space_editor)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}({self.parent}, {self.name}. {self.description},"
+            + f" {self.generator_space}, {self.enemy_space})"
+        )
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelInformationEditorDisplay)
+            and self.name == other.name
+            and self.description == other.description
+            and self.generator_space == other.generator_space
+            and self.enemy_space == other.enemy_space
+        )
+
+    @property
+    def name(self) -> str:
+        """
+        Provides the name of the level.
+
+        Returns
+        -------
+        str
+            The name of the level.
+        """
+        return self.name_editor.text()
+
+    @name.setter
+    def name(self, name: str):
+        self.name_editor.setText(name)
+
+    @property
+    def description(self) -> str:
+        """
+        Provides the description of the level.
+
+        Returns
+        -------
+        str
+            The description of the level.
+        """
+        return self.description_editor.text()
+
+    @description.setter
+    def description(self, description: str):
+        self.description_editor.setText(description)
+
+    @property
+    def generator_space(self) -> int:
+        """
+        Provides the space for generators inside of the level.
+
+        Returns
+        -------
+        int
+            The space for generators inside of the level.
+        """
+        return self.generator_space_editor.value()
+
+    @generator_space.setter
+    def generator_space(self, generator_space: int):
+        self.generator_space_editor.setValue(generator_space)
+
+    @property
+    def enemy_space(self) -> int:
+        """
+        Provides the space for enemies inside of the level.
+
+        Returns
+        -------
+        int
+            The space for enemies inside of the level.
+        """
+        return self.enemy_space_editor.value()
+
+    @enemy_space.setter
+    def enemy_space(self, enemy_space: int):
+        self.enemy_space_editor.setValue(enemy_space)

--- a/foundry/gui/LevelStartEditor.py
+++ b/foundry/gui/LevelStartEditor.py
@@ -1,0 +1,381 @@
+from typing import Optional
+
+from attr import attrs, field
+from attr.validators import instance_of
+from PySide6.QtCore import Signal, SignalInstance
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import QComboBox, QFormLayout, QWidget
+
+from foundry.core.UndoController import UndoController
+from foundry.core.validators import range_validator
+from foundry.smb3parse.levels.level_header import MARIO_X_POSITIONS, MARIO_Y_POSITIONS
+
+STR_X_POSITIONS = [f"{position >> 4}. Block ({position:0=#4X})".replace("X", "x") for position in MARIO_X_POSITIONS]
+STR_Y_POSITIONS = [f"{position}. Block ({position:0=#4X})".replace("X", "x") for position in MARIO_Y_POSITIONS]
+ACTIONS = [
+    "None",
+    "Sliding",
+    "Out of pipe ↑",
+    "Out of pipe ↓",
+    "Out of pipe ←",
+    "Out of pipe →",
+    "Running and climbing up ship",
+    "Ship auto scrolling",
+]
+
+
+@attrs(slots=True, auto_attribs=True, eq=True, frozen=True, hash=True)
+class LevelStartState:
+    """
+    The representation of the start parameters for the player for a given level.
+
+    x_position: int
+        The start position for the player.
+    y_position: int
+        The start position for the player.
+    action: int
+        The action the player starts the level doing.
+    """
+
+    x_position: int = field(validator=[instance_of(int), range_validator(0, 3)])
+    y_position: int = field(validator=[instance_of(int), range_validator(0, 7)])
+    action: int = field(validator=[instance_of(int), range_validator(0, 7)])
+
+
+class LevelStartEditor(QWidget):
+    """
+    A widget which controls the GUI associated with editing start of this level.
+
+    Signals
+    -------
+    x_position_changed: SignalInstance[int]
+        A signal which is activated on x position change.
+    y_position_changed: SignalInstance[int]
+        A signal which is activated on y position change.
+    action_changed: SignalInstance[int]
+        A signal which is activated on action change.
+    state_changed: SignalInstance[LevelStartState]
+        A signal which is activated on any state change.
+
+    Attributes
+    ----------
+    level: LevelStartState
+        The model of current graphics.
+    undo_controller: UndoController[LevelStartState]
+        The undo controller, which is responsible for undoing and redoing any action.
+    """
+
+    x_position_changed: SignalInstance = Signal(int)  # type: ignore
+    y_position_changed: SignalInstance = Signal(int)  # type: ignore
+    action_changed: SignalInstance = Signal(int)  # type: ignore
+    state_changed: SignalInstance = Signal(object)  # type: ignore
+
+    undo_controller: UndoController[LevelStartState]
+
+    def __init__(
+        self,
+        parent: Optional[QWidget],
+        state: LevelStartState,
+        undo_controller: Optional[UndoController[LevelStartState]] = None,
+    ):
+        super().__init__(parent)
+        self._state = state
+        self.undo_controller = undo_controller or UndoController(self.state)
+
+        # Set up the display
+        self._display = LevelStartDisplay(self, self.x_position, self.y_position, self.action)
+
+        # Connect signals accordingly
+        self._display.x_position_editor.currentIndexChanged.connect(  # type: ignore
+            lambda *_: self._x_position_update()
+        )
+        self._display.y_position_editor.currentIndexChanged.connect(  # type: ignore
+            lambda *_: self._y_position_update()
+        )
+        self._display.action_editor.currentIndexChanged.connect(lambda *_: self._action_update())  # type: ignore
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.parent}, {self.state}, {self.undo_controller})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelStartEditor)
+            and self.state == other.state
+            and self.undo_controller == other.undo_controller
+        )
+
+    @property
+    def x_position(self) -> int:
+        """
+        Provides the x position the player starts at.
+
+        Returns
+        -------
+        int
+            The x position for the player starts at.
+        """
+        return self.state.x_position
+
+    @x_position.setter
+    def x_position(self, x_position: int):
+        if self.x_position != x_position:
+            self.do(LevelStartState(x_position, self.y_position, self.action))
+
+    @property
+    def y_position(self) -> int:
+        """
+        Provides the y position the player starts at.
+
+        Returns
+        -------
+        int
+            The y position the player starts at.
+        """
+        return self.state.y_position
+
+    @y_position.setter
+    def y_position(self, y_position: int):
+        if self.y_position != y_position:
+            self.do(LevelStartState(self.x_position, y_position, self.action))
+
+    @property
+    def action(self) -> int:
+        """
+        Provides the action the player starts at.
+
+        Returns
+        -------
+        int
+            The action the player starts at.
+        """
+        return self.state.action
+
+    @action.setter
+    def action(self, action: int):
+        if self.action != action:
+            self.do(LevelStartState(self.x_position, self.y_position, action))
+
+    @property
+    def state(self) -> LevelStartState:
+        """
+        Provides the current state of the instance.
+
+        Returns
+        -------
+        LevelStartState
+            A tuple of the x position, y position, and action for the current instance's level.
+        """
+        return self._state
+
+    @state.setter
+    def state(self, state: LevelStartState):
+        if self.state != state:
+            self.do(state)
+
+    def do(self, new_state: LevelStartState) -> LevelStartState:
+        """
+        Does an action through the controller, adding it to the undo stack and clearing the redo
+        stack, respectively.
+
+        Parameters
+        ----------
+        new_state : LevelStartState
+            The new state to be stored.
+
+        Returns
+        -------
+        LevelStartState
+            The new state that has been stored.
+        """
+        self._update_state(new_state)
+        return self.undo_controller.do(new_state)
+
+    @property
+    def can_undo(self) -> bool:
+        """
+        Determines if there is any states inside the undo stack.
+
+        Returns
+        -------
+        bool
+            If there is an undo state available.
+        """
+        return self.undo_controller.can_undo
+
+    def undo(self) -> LevelStartState:
+        """
+        Undoes the last state, bring the previous.
+
+        Returns
+        -------
+        LevelStartState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.undo())
+        return self.state
+
+    @property
+    def can_redo(self) -> bool:
+        """
+        Determines if there is any states inside the redo stack.
+
+        Returns
+        -------
+        bool
+            If there is an redo state available.
+        """
+        return self.undo_controller.can_redo
+
+    def redo(self) -> LevelStartState:
+        """
+        Redoes the previously undone state.
+
+        Returns
+        -------
+        LevelStartState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.redo())
+        return self.state
+
+    def _update_state(self, state: LevelStartState):
+        """
+        Handles all updating of the state, sending any signals and updates to the display if needed.
+
+        Parameters
+        ----------
+        state : LevelStartState
+            The new state of the editor.
+        """
+
+        x_position = state.x_position
+        y_position = state.y_position
+        action = state.action
+
+        if self.undo_controller.state.x_position != x_position or self.x_position != x_position:
+            self.x_position_changed.emit(x_position)
+            self._state = LevelStartState(state.x_position, self.y_position, self.action)
+            self._display.x_position = x_position
+
+        if self.undo_controller.state.y_position != y_position or self.y_position != y_position:
+            self.y_position_changed.emit(y_position)
+            self._state = LevelStartState(self.x_position, state.y_position, self.action)
+            self._display.y_position = y_position
+
+        if self.undo_controller.state.action != action or self.action != action:
+            self.action_changed.emit(action)
+            self._state = LevelStartState(self.x_position, self.y_position, state.action)
+            self._display.action = action
+
+        self.state_changed.emit(state)
+
+    # Updates from display
+
+    def _x_position_update(self):
+        self.x_position = self._display.x_position
+
+    def _y_position_update(self):
+        self.y_position = self._display.y_position
+
+    def _action_update(self):
+        self.action = self._display.action
+
+
+class LevelStartDisplay(QFormLayout):
+    """
+    The active display for the level start editor.
+
+    Attributes
+    ----------
+    x_position_editor: QComboBox
+        The editor for this level's x position.
+    y_position_editor: QComboBox
+        The editor for this level's y position.
+    action_editor: QComboBox
+        The editor for this level's starting action.
+    """
+
+    x_position_editor: QComboBox
+    y_position_editor: QComboBox
+    action_editor: QComboBox
+
+    def __init__(self, parent: Optional[QWidget], x_position: int, y_position: int, action: int):
+        super().__init__(parent)
+
+        self.setFormAlignment(Qt.AlignCenter)  # type: ignore
+
+        self.x_position_editor = QComboBox()
+        self.x_position_editor.addItems(STR_X_POSITIONS)
+
+        self.y_position_editor = QComboBox()
+        self.y_position_editor.addItems(STR_Y_POSITIONS)
+
+        self.action_editor = QComboBox()
+        self.action_editor.addItems(ACTIONS)
+
+        self.x_position = x_position
+        self.y_position = y_position
+        self.action = action
+
+        self.addRow("Starting X: ", self.x_position_editor)
+        self.addRow("Starting Y: ", self.y_position_editor)
+        self.addRow("Action: ", self.action_editor)
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(" + f"{self.parent}, {self.x_position}, {self.y_position}, {self.action})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelStartDisplay)
+            and self.x_position == other.x_position
+            and self.y_position == other.y_position
+            and self.action == other.action
+        )
+
+    @property
+    def x_position(self) -> int:
+        """
+        Provides the x position of this level.
+
+        Returns
+        -------
+        int
+            The x position of for this level.
+        """
+        return self.x_position_editor.currentIndex()
+
+    @x_position.setter
+    def x_position(self, x_position: int):
+        self.x_position_editor.setCurrentIndex(x_position)
+
+    @property
+    def y_position(self) -> int:
+        """
+        Provides the y position of this level.
+
+        Returns
+        -------
+        int
+            The y position of for this level.
+        """
+        return self.y_position_editor.currentIndex()
+
+    @y_position.setter
+    def y_position(self, y_position: int):
+        self.y_position_editor.setCurrentIndex(y_position)
+
+    @property
+    def action(self) -> int:
+        """
+        Provides the action of this level.
+
+        Returns
+        -------
+        int
+            The action of for this level.
+        """
+        return self.action_editor.currentIndex()
+
+    @action.setter
+    def action(self, action: int):
+        self.action_editor.setCurrentIndex(action)

--- a/foundry/gui/LevelWarpEditor.py
+++ b/foundry/gui/LevelWarpEditor.py
@@ -1,0 +1,397 @@
+from typing import Optional
+
+from attr import attrs, field
+from attr.validators import instance_of
+from PySide6.QtCore import Signal, SignalInstance
+from PySide6.QtGui import Qt
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QFormLayout,
+    QLabel,
+    QPushButton,
+    QWidget,
+)
+
+from foundry.core.UndoController import UndoController
+from foundry.core.validators import range_validator
+from foundry.gui.LevelSelector import OBJECT_SET_ITEMS, LevelSelector
+from foundry.gui.settings import FileSettings
+from foundry.gui.Spinner import Spinner
+
+SPINNER_MAX_VALUE = 0x0F_FF_FF
+
+
+@attrs(slots=True, auto_attribs=True, eq=True, frozen=True, hash=True)
+class LevelWarpState:
+    """
+    The next level for a level to warp to.
+
+    generator_pointer: int
+        The generator pointer for the next level.
+    enemy_pointer: int
+        The enemy pointer for the next level.
+    tileset: int
+        The tileset for the next level.
+    """
+
+    generator_pointer: int = field(validator=[instance_of(int), range_validator(0, 0xFFFFFF)])
+    enemy_pointer: int = field(validator=[instance_of(int), range_validator(0, 0xFFFFFF)])
+    tileset: int = field(validator=[instance_of(int), range_validator(0, 15)])
+
+
+class LevelWarpEditor(QWidget):
+    """
+    A widget which controls the GUI associated with editing warp destination for a given level.
+
+    Signals
+    -------
+    generator_pointer_changed: SignalInstance[int]
+        A signal which is activated on generator pointer change.
+    enemy_pointer_changed: SignalInstance[int]
+        A signal which is activated on enemy pointer change.
+    tileset_changed: SignalInstance[int]
+        A signal which is activated on tileset change.
+    state_changed: SignalInstance[LevelWarpState]
+        A signal which is activated on any state change.
+
+    Attributes
+    ----------
+    level: LevelWarpState
+        The model of current warp destination.
+    undo_controller: UndoController[LevelWarpState]
+        The undo controller, which is responsible for undoing and redoing any action.
+    file_settings: FileSettings
+        The settings for determining levels to automatically select the warp state from.
+    """
+
+    generator_pointer_changed: SignalInstance = Signal(int)  # type: ignore
+    enemy_pointer_changed: SignalInstance = Signal(int)  # type: ignore
+    tileset_changed: SignalInstance = Signal(int)  # type: ignore
+    state_changed: SignalInstance = Signal(object)  # type: ignore
+
+    undo_controller: UndoController[LevelWarpState]
+
+    def __init__(
+        self,
+        parent: Optional[QWidget],
+        state: LevelWarpState,
+        undo_controller: Optional[UndoController[LevelWarpState]] = None,
+        file_settings: Optional[FileSettings] = None,
+    ):
+        super().__init__(parent)
+        self._state = state
+        self.undo_controller = undo_controller or UndoController(self.state)
+        self.file_settings = file_settings or FileSettings(levels=[])
+
+        # Set up the display
+        self._display = LevelWarpDisplay(self, self.generator_pointer, self.enemy_pointer, self.tileset)
+
+        # Connect signals accordingly
+        self._display.generator_pointer_editor.valueChanged.connect(  # type: ignore
+            lambda *_: self._generator_pointer_update()
+        )
+        self._display.enemy_pointer_editor.valueChanged.connect(lambda *_: self._enemy_pointer_update())  # type: ignore
+        self._display.tileset_editor.currentIndexChanged.connect(lambda *_: self._tileset_update())  # type: ignore
+        self._display.select_from_level_button.pressed.connect(  # type: ignore
+            lambda *_: self._set_warp_state_from_level()
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.parent}, {self.state}, {self.undo_controller})"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelWarpEditor)
+            and self.state == other.state
+            and self.undo_controller == other.undo_controller
+        )
+
+    @property
+    def generator_pointer(self) -> int:
+        """
+        Provides the generator pointer of the level that it will be warped to.
+
+        Returns
+        -------
+        int
+            The generator pointer of the next level.
+        """
+        return self.state.generator_pointer
+
+    @generator_pointer.setter
+    def generator_pointer(self, generator_pointer: int):
+        if self.generator_pointer != generator_pointer:
+            self.do(LevelWarpState(generator_pointer, self.enemy_pointer, self.tileset))
+
+    @property
+    def enemy_pointer(self) -> int:
+        """
+        Provides the enemy pointer of the level that it will be warped to.
+
+        Returns
+        -------
+        int
+            The enemy pointer of the next level.
+        """
+        return self.state.enemy_pointer
+
+    @enemy_pointer.setter
+    def enemy_pointer(self, enemy_pointer: int):
+        if self.enemy_pointer != enemy_pointer:
+            self.do(LevelWarpState(self.generator_pointer, enemy_pointer, self.tileset))
+
+    @property
+    def tileset(self) -> int:
+        """
+        Provides the tileset of the level that it will be warped to.
+
+        Returns
+        -------
+        int
+            The tileset of the next level.
+        """
+        return self.state.tileset
+
+    @tileset.setter
+    def tileset(self, tileset: int):
+        if self.tileset != tileset:
+            self.do(LevelWarpState(self.generator_pointer, self.enemy_pointer, tileset))
+
+    @property
+    def state(self) -> LevelWarpState:
+        """
+        Provides the current state of the instance.
+
+        Returns
+        -------
+        LevelWarpState
+            A tuple of the name, description, generator size, and enemy size for the current instance's level.
+        """
+        return self._state
+
+    @state.setter
+    def state(self, state: LevelWarpState):
+        if self.state != state:
+            self.do(state)
+
+    def do(self, new_state: LevelWarpState) -> LevelWarpState:
+        """
+        Does an action through the controller, adding it to the undo stack and clearing the redo
+        stack, respectively.
+
+        Parameters
+        ----------
+        new_state : LevelWarpState
+            The new state to be stored.
+
+        Returns
+        -------
+        LevelWarpState
+            The new state that has been stored.
+        """
+        self._update_state(new_state)
+        return self.undo_controller.do(new_state)
+
+    @property
+    def can_undo(self) -> bool:
+        """
+        Determines if there is any states inside the undo stack.
+
+        Returns
+        -------
+        bool
+            If there is an undo state available.
+        """
+        return self.undo_controller.can_undo
+
+    def undo(self) -> LevelWarpState:
+        """
+        Undoes the last state, bring the previous.
+
+        Returns
+        -------
+        LevelWarpState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.undo())
+        return self.state
+
+    @property
+    def can_redo(self) -> bool:
+        """
+        Determines if there is any states inside the redo stack.
+
+        Returns
+        -------
+        bool
+            If there is an redo state available.
+        """
+        return self.undo_controller.can_redo
+
+    def redo(self) -> LevelWarpState:
+        """
+        Redoes the previously undone state.
+
+        Returns
+        -------
+        LevelWarpState
+            The new state that has been stored.
+        """
+        self._update_state(self.undo_controller.redo())
+        return self.state
+
+    def _update_state(self, state: LevelWarpState):
+        """
+        Handles all updating of the state, sending any signals and updates to the display if needed.
+
+        Parameters
+        ----------
+        state : LevelWarpState
+            The new state of the editor.
+        """
+
+        generator_pointer = state.generator_pointer
+        enemy_pointer = state.enemy_pointer
+        tileset = state.tileset
+
+        if (
+            self.undo_controller.state.generator_pointer != generator_pointer
+            or self.generator_pointer != generator_pointer
+        ):
+            self.generator_pointer_changed.emit(generator_pointer)
+            self._state = LevelWarpState(state.generator_pointer, self.enemy_pointer, self.tileset)
+            self._display.generator_pointer = generator_pointer
+
+        if self.undo_controller.state.enemy_pointer != enemy_pointer or self.enemy_pointer != enemy_pointer:
+            self.enemy_pointer_changed.emit(enemy_pointer)
+            self._state = LevelWarpState(self.generator_pointer, state.enemy_pointer, self.tileset)
+            self._display.enemy_pointer = enemy_pointer
+
+        if self.undo_controller.state.tileset != tileset or self.tileset != tileset:
+            self.tileset_changed.emit(tileset)
+            self._state = LevelWarpState(self.generator_pointer, self.enemy_pointer, state.tileset)
+            self._display.tileset = tileset
+
+        self.state_changed.emit(state)
+
+    # Updates from display
+
+    def _generator_pointer_update(self):
+        self.generator_pointer = self._display.generator_pointer
+
+    def _enemy_pointer_update(self):
+        self.enemy_pointer = self._display.enemy_pointer
+
+    def _tileset_update(self):
+        self.tileset = self._display.tileset
+
+    def _set_warp_state_from_level(self):
+        level_selector = LevelSelector(self, self.file_settings)
+        level_was_selected = level_selector.exec_() == QDialog.Accepted
+
+        if level_was_selected:
+            self.state = LevelWarpState(
+                level_selector.object_data_offset, level_selector.enemy_data_offset, level_selector.object_set
+            )
+
+
+class LevelWarpDisplay(QFormLayout):
+    """
+    The active display for the level warp editor.
+
+    Attributes
+    ----------
+    generator_pointer_editor: Spinner
+        The editor for the next area's generator pointer.
+    enemy_pointer_editor: Spinner
+        The editor for the next area's enemy pointer.
+    tileset_editor: QComboBox
+        The editor for the next area's tileset.
+    """
+
+    generator_pointer_editor: Spinner
+    enemy_pointer_editor: Spinner
+    tileset_editor: QComboBox
+
+    def __init__(self, parent: Optional[QWidget], generator_pointer: int, enemy_pointer: int, tileset: int):
+        super().__init__(parent)
+
+        self.setFormAlignment(Qt.AlignCenter)  # type: ignore
+
+        self.generator_pointer_editor = Spinner(None, maximum=SPINNER_MAX_VALUE)
+        self.enemy_pointer_editor = Spinner(None, maximum=SPINNER_MAX_VALUE)
+        self.tileset_editor = QComboBox()
+        self.tileset_editor.addItems(OBJECT_SET_ITEMS)
+        self.select_from_level_button = QPushButton("Set from Level")
+
+        self.generator_pointer = generator_pointer
+        self.enemy_pointer = enemy_pointer
+        self.tileset = tileset
+
+        self.addRow("Generator Address: ", self.generator_pointer_editor)
+        self.addRow("Enemy Address: ", self.enemy_pointer_editor)
+        self.addRow("Tileset: ", self.tileset_editor)
+        self.addRow(QLabel(""))
+        self.addRow(self.select_from_level_button)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}({self.parent}, {self.generator_pointer}, {self.enemy_pointer}, {self.tileset})"
+        )
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, LevelWarpDisplay)
+            and self.generator_pointer == other.generator_pointer
+            and self.enemy_pointer == other.enemy_pointer
+            and self.tileset == other.tileset
+        )
+
+    @property
+    def generator_pointer(self) -> int:
+        """
+        Provides the generator pointer of the level that it will be warped to.
+
+        Returns
+        -------
+        int
+            The generator pointer of the next level.
+        """
+        return self.generator_pointer_editor.value()
+
+    @generator_pointer.setter
+    def generator_pointer(self, generator_pointer: int):
+        self.generator_pointer_editor.setValue(generator_pointer)
+
+    @property
+    def enemy_pointer(self) -> int:
+        """
+        Provides the enemy pointer of the level that it will be warped to.
+
+        Returns
+        -------
+        int
+            The enemy pointer of the next level.
+        """
+        return self.enemy_pointer_editor.value()
+
+    @enemy_pointer.setter
+    def enemy_pointer(self, enemy_pointer: int):
+        self.enemy_pointer_editor.setValue(enemy_pointer)
+
+    @property
+    def tileset(self) -> int:
+        """
+        Provides the tileset of the level that it will be warped to.
+
+        Returns
+        -------
+        int
+            The tileset of the next level.
+        """
+        return self.tileset_editor.currentIndex()
+
+    @tileset.setter
+    def tileset(self, tileset: int):
+        self.tileset_editor.setCurrentIndex(tileset)

--- a/foundry/gui/settings.py
+++ b/foundry/gui/settings.py
@@ -1,11 +1,18 @@
-import json
+from enum import Enum
+from json import loads
+from os.path import exists
 
+from attr import attrs, field
+from pydantic import BaseModel
 from qt_material import build_stylesheet
 
-from foundry import default_settings_path
-
-RESIZE_LEFT_CLICK = "LMB"
-RESIZE_RIGHT_CLICK = "RMB"
+from foundry import default_settings_path, default_styles_path, file_settings_path
+from foundry.game.level.util import (
+    Level,
+    PydanticLevel,
+    generate_default_level_information,
+    to_pydantic_level,
+)
 
 
 def set_style(theme):
@@ -15,63 +22,308 @@ def set_style(theme):
     return wrapped
 
 
-GUI_STYLE = {
-    "DARK AMBER": set_style("dark_amber.xml"),
-    "DARK BLUE": set_style("dark_blue.xml"),
-    "DARK CYAN": set_style("dark_cyan.xml"),
-    "DARK GREEN": set_style("dark_lightgreen.xml"),
-    "DARK PINK": set_style("dark_pink.xml"),
-    "DARK PURPLE": set_style("dark_purple.xml"),
-    "DARK RED": set_style("dark_red.xml"),
-    "DARK TEAL": set_style("dark_teal.xml"),
-    "DARK YELLOW": set_style("dark_yellow.xml"),
-    "LIGHT AMBER": set_style("light_amber.xml"),
-    "LIGHT BLUE": set_style("light_blue.xml"),
-    "LIGHT CYAN": set_style("light_cyan.xml"),
-    "LIGHT GREEN": set_style("light_lightgreen.xml"),
-    "LIGHT PINK": set_style("light_pink.xml"),
-    "LIGHT PURPLE": set_style("light_purple.xml"),
-    "LIGHT RED": set_style("light_red.xml"),
-    "LIGHT TEAL": set_style("light_teal.xml"),
-    "LIGHT YELLOW": set_style("light_yellow.xml"),
-}
+class ResizeModes(str, Enum):
+    """
+    A declaration of the possible resize modes accepted by the editor.
+    """
 
-SETTINGS = dict()
-SETTINGS["instaplay_emulator"] = "fceux"
-SETTINGS["instaplay_arguments"] = "%f"
-SETTINGS["default_powerup"] = 0
-SETTINGS["default_power_has_star"] = False
-SETTINGS["default_starting_world"] = 0
-
-SETTINGS["resize_mode"] = RESIZE_LEFT_CLICK
-SETTINGS["gui_style"] = ""  # initially blank, since we can't call load_stylesheet until the app is started
-
-SETTINGS["draw_mario"] = True
-SETTINGS["draw_jumps"] = False
-SETTINGS["draw_grid"] = False
-SETTINGS["draw_expansion"] = False
-SETTINGS["draw_jump_on_objects"] = True
-SETTINGS["draw_items_in_blocks"] = True
-SETTINGS["draw_invisible_items"] = True
-SETTINGS["draw_autoscroll"] = False
-SETTINGS["block_transparency"] = True
-SETTINGS["object_scroll_enabled"] = False
-SETTINGS["object_tooltip_enabled"] = True
+    RESIZE_LEFT_CLICK = "LMB"
+    RESIZE_RIGHT_CLICK = "RMB"
 
 
-def load_settings():
-    if not default_settings_path.exists():
-        return
+class GUIStyle(str, Enum):
+    """
+    A declaration of the possible GUI Styles offered by Foundry.
+    """
 
+    DARK_AMBER = "DARK AMBER"
+    DARK_BLUE = "DARK BLUE"
+    DARK_CYAN = "DARK CYAN"
+    DARK_GREEN = "DARK GREEN"
+    DARK_PINK = "DARK PINK"
+    DARK_PURPLE = "DARK PURPLE"
+    DARK_RED = "DARK RED"
+    DARK_TEAL = "DARK TEAL"
+    DARK_YELLOW = "DARK YELLOW"
+    LIGHT_AMBER = "LIGHT AMBER"
+    LIGHT_BLUE = "LIGHT BLUE"
+    LIGHT_CYAN = "LIGHT CYAN"
+    LIGHT_GREEN = "LIGHT GREEN"
+    LIGHT_PINK = "LIGHT PINK"
+    LIGHT_PURPLE = "LIGHT PURPLE"
+    LIGHT_RED = "LIGHT RED"
+    LIGHT_TEAL = "LIGHT TEAL"
+    LIGHT_YELLOW = "LIGHT YELLOW"
+
+
+class GUILoader(BaseModel):
+    style: dict[GUIStyle, str]
+
+    def load_style(self, style: GUIStyle):
+        return set_style(self.style[style])
+
+    class Config:
+        # Allow storing the enum as a string
+        use_enum_values = True
+
+
+@attrs(auto_attribs=True, slots=True)
+class FileSettings:
+    """
+    Settings dedicated to a specific file.
+
+    Attributes
+    ----------
+    levels: list[Level]
+        The list of all levels contained inside the file.
+    """
+
+    levels: list[Level] = field(factory=generate_default_level_information)
+
+
+@attrs(auto_attribs=True, slots=True)
+class UserSettings:
+    """
+    The settings for the user for Foundry.
+
+    Attributes
+    ----------
+    gui_style: GUIStyle
+        The style used for the GUI.
+    instaplay_emulator: str
+        The path to the emulator.
+    instaplay_arguments: str
+        Any additional arguments passed to the emulator.
+    default_powerup: int
+        The default powerup to start the player with for testing.
+    default_power_has_star: bool
+        If the player will start with a star for testing.
+    default_starting_world: int
+        Which world the player will start in for testing.
+    resize_mode: ResizeModes
+        Determines how generators can be expanded.
+    draw_mario: bool
+        Draws the start location of Mario.
+    draw_jumps: bool
+        Draws the warp indexes of the level.
+    draw_grid: bool
+        Draws a grid for the level.
+    draw_expansion: bool
+        Draws the ways generators can expand.
+    draw_jump_on_objects: bool
+        Draws if an generator will warp the player.
+    draw_items_in_blocks: bool
+        Draw any items located inside a generator.
+    draw_invisible_items: bool
+        Draw invisible items.
+    draw_autoscroll: bool
+        Draws autoscroll routes.
+    block_transparency: bool
+        Causes generators to be drawn with transparency.
+    object_scroll_enabled: bool
+        Enables the editing of generators through the use of the scroll wheel.
+    object_tooltip_enabled: bool
+        Enables tooltips for generators.
+    """
+
+    gui_style: GUIStyle = GUIStyle.LIGHT_BLUE
+    instaplay_emulator: str = "fceux"
+    instaplay_arguments: str = "%f"
+    default_powerup: int = 0
+    default_power_has_star: bool = False
+    default_starting_world: int = 0
+    resize_mode: ResizeModes = ResizeModes.RESIZE_LEFT_CLICK
+    draw_mario: bool = True
+    draw_jumps: bool = False
+    draw_grid: bool = False
+    draw_expansion: bool = False
+    draw_jump_on_objects: bool = True
+    draw_items_in_blocks: bool = True
+    draw_invisible_items: bool = True
+    draw_autoscroll: bool = False
+    block_transparency: bool = True
+    object_scroll_enabled: bool = False
+    object_tooltip_enabled: bool = True
+
+
+class PydanticFileSettings(BaseModel):
+    levels: list[PydanticLevel]
+
+
+class PydanticUserSettings(BaseModel):
+    gui_style: GUIStyle = GUIStyle.LIGHT_BLUE
+    instaplay_emulator: str = "fceux"
+    instaplay_arguments: str = "%f"
+    default_powerup: int = 0
+    default_power_has_star: bool = False
+    default_starting_world: int = 0
+    resize_mode: ResizeModes = ResizeModes.RESIZE_LEFT_CLICK
+    draw_mario: bool = True
+    draw_jumps: bool = False
+    draw_grid: bool = False
+    draw_expansion: bool = False
+    draw_jump_on_objects: bool = True
+    draw_items_in_blocks: bool = True
+    draw_invisible_items: bool = True
+    draw_autoscroll: bool = False
+    block_transparency: bool = True
+    object_scroll_enabled: bool = False
+    object_tooltip_enabled: bool = True
+
+    def to_user_settings(self) -> UserSettings:
+        """
+        Generates a user setting.
+
+        Returns
+        -------
+        UserSettings
+            The representation of this instance as a user setting.
+        """
+        return UserSettings(
+            gui_style=self.gui_style,
+            instaplay_emulator=self.instaplay_emulator,
+            instaplay_arguments=self.instaplay_arguments,
+            default_powerup=self.default_powerup,
+            default_power_has_star=self.default_power_has_star,
+            default_starting_world=self.default_starting_world,
+            resize_mode=self.resize_mode,
+            draw_mario=self.draw_mario,
+            draw_jumps=self.draw_jumps,
+            draw_grid=self.draw_grid,
+            draw_expansion=self.draw_expansion,
+            draw_jump_on_objects=self.draw_jump_on_objects,
+            draw_items_in_blocks=self.draw_items_in_blocks,
+            draw_invisible_items=self.draw_invisible_items,
+            draw_autoscroll=self.draw_autoscroll,
+            block_transparency=self.block_transparency,
+            object_scroll_enabled=self.object_scroll_enabled,
+            object_tooltip_enabled=self.object_tooltip_enabled,
+        )
+
+    class Config:
+        # Allow storing the enum as a string
+        use_enum_values = True
+
+
+def user_setting_to_json(user_setting: UserSettings, path: str):
+    p_user_setting = PydanticUserSettings(
+        gui_style=user_setting.gui_style,
+        instaplay_emulator=user_setting.instaplay_emulator,
+        instaplay_arguments=user_setting.instaplay_arguments,
+        default_powerup=user_setting.default_powerup,
+        default_power_has_star=user_setting.default_power_has_star,
+        default_starting_world=user_setting.default_starting_world,
+        resize_mode=user_setting.resize_mode,
+        draw_mario=user_setting.draw_mario,
+        draw_jumps=user_setting.draw_jumps,
+        draw_grid=user_setting.draw_grid,
+        draw_expansion=user_setting.draw_expansion,
+        draw_jump_on_objects=user_setting.draw_jump_on_objects,
+        draw_items_in_blocks=user_setting.draw_items_in_blocks,
+        draw_invisible_items=user_setting.draw_invisible_items,
+        draw_autoscroll=user_setting.draw_autoscroll,
+        block_transparency=user_setting.block_transparency,
+        object_scroll_enabled=user_setting.object_scroll_enabled,
+        object_tooltip_enabled=user_setting.object_tooltip_enabled,
+    )
+
+    with open(path, "w") as settings_file:
+        settings_file.write(p_user_setting.json(indent=4))
+
+
+def to_pydantic_file_settings(file_settings: FileSettings) -> PydanticFileSettings:
+    """
+    Converts file settings to its pydantic equivelant.
+
+    Parameters
+    ----------
+    file_settings : FileSettings
+        The file settings to convert.
+
+    Returns
+    -------
+    PydanticFileSettings
+        The pydantic equivelant of the file settings provided.
+    """
+    return PydanticFileSettings(levels=[to_pydantic_level(level) for level in file_settings.levels])
+
+
+def load_gui_loader() -> GUILoader:
+    """
+    Generates mappings to load the possible GUI styles.
+
+    Returns
+    -------
+    GUILoader
+        The loader for the GUI styles.
+    """
+    with open(default_styles_path, "r") as f:
+        return GUILoader(style=loads(f.read()))
+
+
+def load_file_settings(file_id: str) -> FileSettings:
+    """
+    Attempts to load the file settings for a given file.  If none exists, then the default file settings
+    will be utilized instead.
+
+    Parameters
+    ----------
+    file_id : str
+        The file name for the file settings.
+
+    Returns
+    -------
+    FileSettings
+        The file settings that best match the provided file.
+    """
+    if not exists(file_settings_path / file_id):
+        return FileSettings()
+    try:
+        with open(file_settings_path / file_id, "r") as f:
+            return FileSettings([PydanticLevel(**level).to_level() for level in loads(f.read())["levels"]])
+    except TypeError:
+        # Todo: Probably should add a warning to the user here.
+        return FileSettings()
+
+
+def save_file_settings(file_id: str, file_settings: FileSettings):
+    """
+    Saves file settings to a file.
+
+    Parameters
+    ----------
+    file_id : str
+        The file to save the settings for.
+    file_settings : FileSettings
+        The settings to save.
+    """
+    with open(file_settings_path / file_id, "w") as settings_file:
+        settings_file.write(to_pydantic_file_settings(file_settings).json(indent=4))
+
+
+def load_settings() -> UserSettings:
+    """
+    Provides the user settings.
+
+    Returns
+    -------
+    UserSettings
+        The current user settings.
+    """
     try:
         with open(str(default_settings_path), "r") as settings_file:
-            settings_dict = json.loads(settings_file.read())
-    except json.JSONDecodeError:
-        return
-
-    SETTINGS.update(settings_dict)
+            return PydanticUserSettings(**loads(settings_file.read())).to_user_settings()
+    except (TypeError, FileNotFoundError):
+        return PydanticUserSettings().to_user_settings()
 
 
-def save_settings():
-    with open(str(default_settings_path), "w") as settings_file:
-        settings_file.write(json.dumps(SETTINGS, indent=4, sort_keys=True))
+def save_settings(user_settings: UserSettings):
+    """
+    Saves the user settings to a file.
+
+    Parameters
+    ----------
+    user_settings : UserSettings
+        The user settings to save.
+    """
+    user_setting_to_json(user_settings, str(default_settings_path))

--- a/foundry/gui/util.py
+++ b/foundry/gui/util.py
@@ -16,7 +16,7 @@ from PySide6.QtWidgets import (
 )
 
 from foundry import open_url
-from foundry.gui.settings import SETTINGS
+from foundry.gui.settings import UserSettings
 
 ID_PROP = "ID"
 
@@ -575,7 +575,7 @@ def setup_layout(parent: QWidget, flags: dict) -> QLayout:
     return layout
 
 
-def setup_widget_menu(widget: QMainWindow, flags):
+def setup_widget_menu(widget: QMainWindow, flags, user_settings: UserSettings):
     for menu_name, menu in flags["menu"].items():
         qmenu = QMenu(menu["name"])
         if menu.get("attribute", False):
@@ -617,9 +617,9 @@ def setup_widget_menu(widget: QMainWindow, flags):
                     action = qmenu.addAction(name)
                     action.setProperty(ID_PROP, option["id"])
                     action.setCheckable(True)
-                    action.setChecked(SETTINGS[option["name"]])
+                    action.setChecked(getattr(user_settings, option["name"]))
         widget.menuBar().addMenu(qmenu)
 
 
-def setup_window(widget: QMainWindow, flags):
-    setup_widget_menu(widget, flags)
+def setup_window(widget: QMainWindow, flags, user_settings: UserSettings):
+    setup_widget_menu(widget, flags, user_settings)

--- a/foundry/main.py
+++ b/foundry/main.py
@@ -10,7 +10,7 @@ from PySide6.QtWidgets import QApplication, QMessageBox
 
 from foundry import auto_save_rom_path, github_issue_link
 from foundry.gui.AutoSaveDialog import AutoSaveDialog
-from foundry.gui.settings import load_settings, save_settings
+from foundry.gui.settings import load_gui_loader, load_settings, save_settings
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ def start():
     parser.add_argument(
         "--dev", default=False, action=BooleanOptionalAction, type=bool, help="Override path with system path"
     )
-    parser.add_argument("--level", type=int, help="Level index", default=None)
+    parser.add_argument("--level", type=int, help="PydanticLevel index", default=None)
     parser.add_argument("--world", type=int, help="World Index", default=None)
 
     args = parser.parse_args()
@@ -41,7 +41,8 @@ def start():
 
 
 def main(path_to_rom: str = "", world=None, level=None):
-    load_settings()
+    user_settings = load_settings()
+    gui_loader = load_gui_loader()
 
     app = QApplication()
 
@@ -55,11 +56,11 @@ def main(path_to_rom: str = "", world=None, level=None):
                 None, "Auto Save recovered", "Don't forget to save the loaded ROM under a new name!"
             )
 
-    window = MainWindow(path_to_rom, world, level)
+    window = MainWindow(path_to_rom, world, level, user_settings=user_settings, gui_loader=gui_loader)
     if window.loaded:
         del window.loaded
         app.exec_()
-        save_settings()
+        save_settings(user_settings)
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ level_1_2_enemy_address = 0xC6BA + 1
 
 @pytest.fixture
 def level(rom_singleton, qtbot):
-    return Level("Level 1-1", level_1_1_object_address, level_1_1_enemy_address, PLAINS_OBJECT_SET)
+    return Level("PydanticLevel 1-1", level_1_1_object_address, level_1_1_enemy_address, PLAINS_OBJECT_SET)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/core/test_undo_controller.py
+++ b/tests/core/test_undo_controller.py
@@ -15,6 +15,80 @@ def undo_controller(draw, min_size: int = 0, max_size: Optional[int] = None):
     return controller
 
 
+def test_equality_simple():
+    controller1 = UndoController(0)
+    controller2 = UndoController(0)
+    assert controller1 == controller2
+
+
+def test_inequality_simple():
+    controller1 = UndoController(0)
+    controller2 = UndoController(1)
+    assert controller1 != controller2
+
+
+def test_equality_with_undo():
+    controller1 = UndoController(0)
+    controller2 = UndoController(0)
+    controller1.do(1)
+    controller2.do(1)
+    controller1.undo()
+    controller2.undo()
+    assert controller1 == controller2
+
+
+def test_inequality_with_undo():
+    controller1 = UndoController(0)
+    controller2 = UndoController(0)
+    controller1.do(1)
+    controller2.do(2)
+    controller1.undo()
+    controller2.undo()
+    assert controller1 != controller2
+
+
+def test_inequality_with_undo_and_normal():
+    controller1 = UndoController(0)
+    controller2 = UndoController(0)
+    controller1.do(1)
+    controller1.undo()
+    assert controller1 != controller2
+
+
+def test_equality_with_redo():
+    controller1 = UndoController(0)
+    controller2 = UndoController(0)
+    controller1.do(1)
+    controller2.do(1)
+    controller1.undo()
+    controller2.undo()
+    controller1.redo()
+    controller2.redo()
+    assert controller1 == controller2
+
+
+def test_inequality_with_redo():
+    controller1 = UndoController(0)
+    controller2 = UndoController(0)
+    controller1.do(1)
+    controller2.do(2)
+    controller1.undo()
+    controller2.undo()
+    controller1.redo()
+    controller2.redo()
+    assert controller1 != controller2
+
+
+def test_equality_with_redo_and_normal():
+    controller1 = UndoController(0)
+    controller2 = UndoController(0)
+    controller1.do(1)
+    controller2.do(1)
+    controller1.undo()
+    controller1.redo()
+    assert controller1 == controller2
+
+
 def test_do():
     controller = UndoController(0)
     controller.do(1)

--- a/tests/game/level/test_level_drawing.py
+++ b/tests/game/level/test_level_drawing.py
@@ -9,6 +9,7 @@ from foundry.game.gfx.drawable.Block import Block
 from foundry.game.level.LevelRef import LevelRef
 from foundry.gui.ContextMenu import ContextMenu
 from foundry.gui.LevelView import LevelView
+from foundry.gui.settings import FileSettings, UserSettings
 from foundry.smb3parse.levels import HEADER_LENGTH
 from foundry.smb3parse.objects.object_set import WORLD_MAP_OBJECT_SET
 from tests.conftest import compare_images
@@ -57,8 +58,8 @@ with open(data_dir / "levels.dat", "r") as level_data_file:
         level_data.append((level_name, level_address, enemy_address, object_set_number, False))
         level_data.append((level_name, level_address, enemy_address, object_set_number, True))
 
-        test_name.append(f"Level {world_no}-{level_no} - {level_name}, no transparency")
-        test_name.append(f"Level {world_no}-{level_no} - {level_name}")
+        test_name.append(f"PydanticLevel {world_no}-{level_no} - {level_name}, no transparency")
+        test_name.append(f"PydanticLevel {world_no}-{level_no} - {level_name}")
 
 
 @pytest.mark.parametrize("level_info", level_data, ids=test_name)
@@ -72,7 +73,7 @@ def test_level(level_info, qtbot):
     # monkeypatch level names, since the level name data is broken atm
     level_ref.level.name = current_test_name()
 
-    level_view = LevelView(None, level_ref, ContextMenu(level_ref))
+    level_view = LevelView(None, level_ref, ContextMenu(level_ref), FileSettings(), UserSettings())
     level_view.transparency = transparent
     level_view.draw_jumps = False
     level_view.draw_grid = False
@@ -102,7 +103,7 @@ def test_draw_m3ls(m3l_file_name, level, qtbot):
         ref = LevelRef()
         ref._internal_level = level
 
-        view = LevelView(None, ref, ContextMenu(ref))
+        view = LevelView(None, ref, ContextMenu(ref), FileSettings(), UserSettings())
         view.draw_grid = False
 
         compare_images(m3l_file_name.stem, str(reference_image_dir / f"{m3l_file_name.stem}.png"), view.grab())

--- a/tests/game/test_file.py
+++ b/tests/game/test_file.py
@@ -191,12 +191,6 @@ def test_bulk_read_global_program_bank(rom_singleton: ROM):
     ) == rom_singleton.bulk_read(0x10, 0x3C010)
 
 
-def test_bulk_read_end(rom_singleton: ROM):
-    assert bytes(
-        [0x33, 0x0, 0x0, 0x6C, 0x56, 0x3, 0x0, 0x1, 0xC, 0x1, 0x2D, 0x86, 0xF4, 0x40, 0xFF, 0x95]
-    ) == rom_singleton.bulk_read(0x10, 0x3FFFF)
-
-
 def test_bulk_write_header(rom_singleton: ROM):
     rom_singleton.bulk_write(bytearray([0] * 0x10), 0)
     assert bytes([0] * 0x10) == rom_singleton.bulk_read(0x10, 0)
@@ -215,3 +209,7 @@ def test_bulk_write_global_program_bank(rom_singleton: ROM):
 def test_bulk_write_end(rom_singleton: ROM):
     rom_singleton.bulk_write(bytearray([0] * 0x10), 0x3FFFF)
     assert bytes([0] * 0x10) == rom_singleton.bulk_read(0x10, 0x3FFFF)
+
+
+def test_tagged_file(rom_singleton: ROM):
+    assert rom_singleton.rom_data.find(rom_singleton.MARKER_VALUE) > 0

--- a/tests/gui/test_header_editor.py
+++ b/tests/gui/test_header_editor.py
@@ -1,75 +1,1711 @@
-import pytest
-from PySide6.QtWidgets import QCheckBox, QComboBox
+from hypothesis import given
+from hypothesis.strategies import booleans, builds, integers, lists, text
+from PySide6.QtWidgets import QMainWindow
+from pytest import fixture
 
-from foundry.game.gfx.objects.LevelObject import SCREEN_WIDTH
-from foundry.game.level.Level import Level
-from foundry.gui.HeaderEditor import HeaderEditor
-
-
-@pytest.fixture
-def header_editor(main_window):
-    level = main_window.manager.controller.level_ref
-
-    return HeaderEditor(None, level)
-
-
-def _test_dropdown(dropdown: QComboBox, level: Level, level_attr: str, expected_change, index_change=+1):
-    # WHEN the combobox has been changed using the header editor
-    old_index = dropdown.currentIndex()
-    old_attr_value = getattr(level, level_attr)
-
-    new_index = old_index + index_change
-
-    assert new_index > 0
-
-    dropdown.setCurrentIndex(new_index)
-    dropdown.activated.emit(new_index)
-
-    new_attr_value = getattr(level, level_attr)
-
-    # THEN the level attribute should have changed
-    assert new_attr_value == old_attr_value + expected_change
-
-
-def _test_check_box(check_box: QCheckBox, level: Level, level_attr: str, expected_value):
-    old_checked_status = check_box.isChecked()
-    old_attr_value = getattr(level, level_attr)
-
-    check_box.click()
-
-    new_attr_value = getattr(level, level_attr)
-
-    assert check_box.isChecked() != old_checked_status
-    assert old_attr_value != new_attr_value
-    assert new_attr_value == expected_value
-
-
-@pytest.mark.parametrize(
-    "dropdown, level_attr, expected_change",
-    [
-        ("length_dropdown", "length", +SCREEN_WIDTH),
-        ("music_dropdown", "music_index", +1),
-        ("time_dropdown", "time_index", +1),
-        ("v_scroll_direction_dropdown", "scroll_type", +1),
-        ("x_position_dropdown", "start_x_index", +1),
-        ("action_dropdown", "start_action", +1),
-        ("graphic_set_dropdown", "graphic_set", +1),
-        ("next_area_object_set_dropdown", "next_area_object_set", +1),
-    ],
+from foundry.game.level.util import DisplayInformation
+from foundry.game.level.util import Level as LevelInformationState
+from foundry.game.level.util import Location
+from foundry.gui.HeaderEditor import (
+    HeaderDisplay,
+    HeaderEditor,
+    HeaderState,
+    header_state_to_level_header,
 )
-def test_dropdown(header_editor, dropdown, level_attr, expected_change):
-    _test_dropdown(getattr(header_editor, dropdown), header_editor.level, level_attr, expected_change)
+from foundry.gui.LevelDataEditor import LevelDataState
+from foundry.gui.LevelGraphicsEditor import LevelGraphicsState
+from foundry.gui.LevelStartEditor import LevelStartState
+from foundry.gui.LevelWarpEditor import LevelWarpState
+from foundry.gui.settings import FileSettings
 
 
-def test_y_starting_point(header_editor):
-    _test_dropdown(
-        getattr(header_editor, "y_position_dropdown"), header_editor.level, "start_y_index", -1, index_change=-1
+def level_data_states():
+    return builds(
+        LevelDataState, integers(0, 15), integers(0, 63), integers(0, 3), integers(0, 3), booleans(), booleans()
     )
 
 
-@pytest.mark.parametrize(
-    "check_box_name, level_attr, expected_value",
-    [("pipe_ends_level_cb", "pipe_ends_level", True), ("level_is_vertical_cb", "is_vertical", True)],
-)
-def test_check_box(header_editor, check_box_name, level_attr, expected_value):
-    _test_check_box(getattr(header_editor, check_box_name), header_editor.level, level_attr, expected_value)
+def level_start_states():
+    return builds(LevelStartState, integers(0, 3), integers(0, 7), integers(0, 7))
+
+
+def level_graphics_states():
+    return builds(LevelGraphicsState, integers(0, 7), integers(0, 3), integers(0, 31))
+
+
+def level_warp_states():
+    return builds(LevelWarpState, integers(0, 0xFFFF), integers(0, 0xFFFF), integers(0, 15))
+
+
+def level_locations():
+    return builds(Location, integers(0, 8), integers(0))
+
+
+def display_info():
+    return builds(DisplayInformation, text(), text(), lists(level_locations()))
+
+
+def level_info_states():
+    return builds(
+        LevelInformationState,
+        display_info(),
+        integers(0, 0xFFFF),
+        integers(0, 0xFFFF),
+        integers(0, 15),
+        integers(0),
+        integers(0),
+    )
+
+
+def header_states():
+    return builds(
+        HeaderState,
+        level_data_states(),
+        level_start_states(),
+        level_graphics_states(),
+        level_warp_states(),
+        level_info_states(),
+    )
+
+
+@fixture
+def header_state() -> HeaderState:
+    return HeaderState(
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+    )
+
+
+@fixture
+def header_state_other() -> HeaderState:
+    return HeaderState(
+        LevelDataState(0, 0, 0, 0, False, True),
+        LevelStartState(2, 1, 0),
+        LevelGraphicsState(0, 0, 0),
+        LevelWarpState(0xEEEE, 0xFFFF, 0),
+        LevelInformationState(DisplayInformation("other name", "other desc", []), 0xCCCC, 0xDDDD, 0, 50, 15),
+    )
+
+
+@fixture
+def level_bytes() -> bytearray:
+    return bytearray([0, 1, 2, 3, 4, 5, 6, 7, 8])
+
+
+@fixture
+def empty_file_settings() -> FileSettings:
+    return FileSettings(levels=[])
+
+
+@fixture(scope="session")
+def temp_app():
+    yield QMainWindow()
+
+
+@fixture
+def header_display(temp_app, level_bytes: bytearray, empty_file_settings: FileSettings) -> HeaderDisplay:
+    return HeaderDisplay(
+        temp_app,
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+        level_bytes,
+        empty_file_settings,
+    )
+
+
+@fixture
+def header_editor(header_state: HeaderState, empty_file_settings: FileSettings) -> HeaderEditor:
+    return HeaderEditor(None, header_state, empty_file_settings)
+
+
+def test_header_state_initialization():
+    HeaderState(
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+    )
+
+
+def test_header_state_equality():
+    assert HeaderState(
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+    ) == HeaderState(
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+    )
+
+
+def test_header_state_inequality(header_state: HeaderState, header_state_other: HeaderState):
+    assert header_state != header_state_other
+
+
+def test_header_state_inequality_other(header_state: HeaderState):
+    assert header_state != 1
+
+
+def test_initialization(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    HeaderEditor(None, header_state, empty_file_settings)
+
+
+def test_normal_equality(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    assert HeaderEditor(None, header_state, empty_file_settings) == HeaderEditor(
+        None, header_state, empty_file_settings
+    )
+
+
+def test_normal_inequality(
+    qtbot, header_state: HeaderState, header_state_other: HeaderState, empty_file_settings: FileSettings
+):  # sourcery skip: de-morgan
+    assert HeaderEditor(None, header_state, empty_file_settings) != HeaderEditor(
+        None, header_state_other, empty_file_settings
+    )
+
+
+def test_equality_undo(
+    qtbot, header_state: HeaderState, header_state_other: HeaderState, empty_file_settings: FileSettings
+):
+    editor1 = HeaderEditor(None, header_state, empty_file_settings)
+    editor2 = HeaderEditor(None, header_state, empty_file_settings)
+    editor1.state = header_state_other
+    editor1.undo()
+    assert editor1 != editor2
+
+    editor2.state = header_state_other
+
+    assert editor1 != editor2
+
+    editor2.undo()
+    assert editor1 == editor2
+
+
+def test_equality_redo(
+    qtbot, header_state: HeaderState, header_state_other: HeaderState, empty_file_settings: FileSettings
+):
+    editor1 = HeaderEditor(None, header_state, empty_file_settings)
+    editor2 = HeaderEditor(None, header_state, empty_file_settings)
+    editor1.state = header_state_other
+    editor1.undo()
+    editor1.redo()
+    assert editor1 != editor2
+
+    editor2.state = header_state_other
+
+    assert editor1 == editor2
+
+    editor2.undo()
+    editor2.redo()
+    assert editor1 == editor2
+
+
+def test_inequality_other(qtbot, header_editor: HeaderEditor):
+    assert header_editor != 5
+
+
+def test_current_page_initialization(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    assert 0 == editor.current_page
+
+
+def test_current_page_get_set(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.current_page = 1
+    assert 1 == editor.current_page
+
+
+def test_level_length_update_level_length_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.level_length_changed, timeout=100):
+        editor.level_length = 3
+
+    assert editor.level_length == 3
+    assert editor.state.data.level_length == 3
+
+
+def test_level_length_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.level_length = 3
+
+    assert editor.level_length == 3
+    assert editor.state.data.level_length == 3
+
+
+def test_level_length_undo_level_length_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.level_length
+    editor.level_length = 3
+
+    with qtbot.waitSignal(editor.level_length_changed, timeout=100):
+        editor.undo()
+
+    assert editor.level_length == expected
+    assert editor.state.data.level_length == expected
+
+
+def test_level_length_undo_level_length_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.level_length
+    editor.level_length = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.level_length == expected
+    assert editor.state.data.level_length == expected
+
+
+def test_level_length_redo_level_length_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.level_length = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.level_length_changed, timeout=100):
+        editor.redo()
+
+    assert editor.level_length == 3
+    assert editor.state.data.level_length == 3
+
+
+def test_level_length_redo_level_length_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.level_length = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.level_length == 3
+    assert editor.state.data.level_length == 3
+
+
+def test_music_update_music_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.music_changed, timeout=100):
+        editor.music = 3
+
+    assert editor.music == 3
+    assert editor.state.data.music == 3
+
+
+def test_music_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.music = 3
+
+    assert editor.music == 3
+    assert editor.state.data.music == 3
+
+
+def test_music_undo_music_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.music
+    editor.music = 3
+
+    with qtbot.waitSignal(editor.music_changed, timeout=100):
+        editor.undo()
+
+    assert editor.music == expected
+    assert editor.state.data.music == expected
+
+
+def test_music_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.music
+    editor.music = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.music == expected
+    assert editor.state.data.music == expected
+
+
+def test_music_redo_music_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.music = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.music_changed, timeout=100):
+        editor.redo()
+
+    assert editor.music == 3
+    assert editor.state.data.music == 3
+
+
+def test_music_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.music = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.music == 3
+    assert editor.state.data.music == 3
+
+
+def test_time_update_time_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.time_changed, timeout=100):
+        editor.time = 3
+
+    assert editor.time == 3
+    assert editor.state.data.time == 3
+
+
+def test_time_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.time = 3
+
+    assert editor.time == 3
+    assert editor.state.data.time == 3
+
+
+def test_time_undo_time_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.time
+    editor.time = 3
+
+    with qtbot.waitSignal(editor.time_changed, timeout=100):
+        editor.undo()
+
+    assert editor.time == expected
+    assert editor.state.data.time == expected
+
+
+def test_time_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.time
+    editor.time = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.time == expected
+    assert editor.state.data.time == expected
+
+
+def test_time_redo_time_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.time = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.time_changed, timeout=100):
+        editor.redo()
+
+    assert editor.time == 3
+    assert editor.state.data.time == 3
+
+
+def test_time_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.time = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.time == 3
+    assert editor.state.data.time == 3
+
+
+def test_scroll_update_scroll_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.scroll_changed, timeout=100):
+        editor.scroll = 3
+
+    assert editor.scroll == 3
+    assert editor.state.data.scroll == 3
+
+
+def test_scroll_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.scroll = 3
+
+    assert editor.scroll == 3
+    assert editor.state.data.scroll == 3
+
+
+def test_scroll_undo_scroll_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.scroll
+    editor.scroll = 3
+
+    with qtbot.waitSignal(editor.scroll_changed, timeout=100):
+        editor.undo()
+
+    assert editor.scroll == expected
+    assert editor.state.data.scroll == expected
+
+
+def test_scroll_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.scroll
+    editor.scroll = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.scroll == expected
+    assert editor.state.data.scroll == expected
+
+
+def test_scroll_redo_scroll_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.scroll = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.scroll_changed, timeout=100):
+        editor.redo()
+
+    assert editor.scroll == 3
+    assert editor.state.data.scroll == 3
+
+
+def test_scroll_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.scroll = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.scroll == 3
+    assert editor.state.data.scroll == 3
+
+
+def test_horizontal_update_horizontal_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.horizontal_changed, timeout=100):
+        editor.horizontal = False
+
+    assert not editor.horizontal
+    assert not editor.state.data.horizontal
+
+
+def test_horizontal_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.horizontal = False
+
+    assert not editor.horizontal
+    assert not editor.state.data.horizontal
+
+
+def test_horizontal_undo_horizontal_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.horizontal
+    editor.horizontal = False
+
+    with qtbot.waitSignal(editor.horizontal_changed, timeout=100):
+        editor.undo()
+
+    assert editor.horizontal == expected
+    assert editor.state.data.horizontal == expected
+
+
+def test_horizontal_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.horizontal
+    editor.horizontal = False
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.horizontal == expected
+    assert editor.state.data.horizontal == expected
+
+
+def test_horizontal_redo_horizontal_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.horizontal = False
+    editor.undo()
+
+    with qtbot.waitSignal(editor.horizontal_changed, timeout=100):
+        editor.redo()
+
+    assert not editor.horizontal
+    assert not editor.state.data.horizontal
+
+
+def test_horizontal_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.horizontal = False
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert not editor.horizontal
+    assert not editor.state.data.horizontal
+
+
+def test_pipe_ends_level_update_pipe_ends_level_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.pipe_ends_level_changed, timeout=100):
+        editor.pipe_ends_level = True
+
+    assert editor.pipe_ends_level
+    assert editor.state.data.pipe_ends_level
+
+
+def test_pipe_ends_level_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.pipe_ends_level = True
+
+    assert editor.pipe_ends_level
+    assert editor.state.data.pipe_ends_level
+
+
+def test_pipe_ends_level_undo_pipe_ends_level_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.pipe_ends_level
+    editor.pipe_ends_level = True
+
+    with qtbot.waitSignal(editor.pipe_ends_level_changed, timeout=100):
+        editor.undo()
+
+    assert editor.pipe_ends_level == expected
+    assert editor.state.data.pipe_ends_level == expected
+
+
+def test_pipe_ends_level_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.pipe_ends_level
+    editor.pipe_ends_level = True
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.pipe_ends_level == expected
+    assert editor.state.data.pipe_ends_level == expected
+
+
+def test_pipe_ends_level_redo_pipe_ends_level_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.pipe_ends_level = True
+    editor.undo()
+
+    with qtbot.waitSignal(editor.pipe_ends_level_changed, timeout=100):
+        editor.redo()
+
+    assert editor.pipe_ends_level
+    assert editor.state.data.pipe_ends_level
+
+
+def test_pipe_ends_level_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.pipe_ends_level = True
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.pipe_ends_level
+    assert editor.state.data.pipe_ends_level
+
+
+def test_x_position_update_x_position_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.x_position_changed, timeout=100):
+        editor.x_position = 3
+
+    assert editor.x_position == 3
+    assert editor.state.start.x_position == 3
+
+
+def test_x_position_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.x_position = 3
+
+    assert editor.x_position == 3
+    assert editor.state.start.x_position == 3
+
+
+def test_x_position_undo_x_position_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.x_position
+    editor.x_position = 3
+
+    with qtbot.waitSignal(editor.x_position_changed, timeout=100):
+        editor.undo()
+
+    assert editor.x_position == expected
+    assert editor.state.start.x_position == expected
+
+
+def test_x_position_undo_x_position_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.x_position
+    editor.x_position = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.x_position == expected
+    assert editor.state.start.x_position == expected
+
+
+def test_x_position_redo_x_position_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.x_position = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.x_position_changed, timeout=100):
+        editor.redo()
+
+    assert editor.x_position == 3
+    assert editor.state.start.x_position == 3
+
+
+def test_x_position_redo_x_position_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.x_position = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.x_position == 3
+    assert editor.state.start.x_position == 3
+
+
+def test_y_position_update_y_position_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.y_position_changed, timeout=100):
+        editor.y_position = 3
+
+    assert editor.y_position == 3
+    assert editor.state.start.y_position == 3
+
+
+def test_y_position_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.y_position = 3
+
+    assert editor.y_position == 3
+    assert editor.state.start.y_position == 3
+
+
+def test_y_position_undo_y_position_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.y_position
+    editor.y_position = 3
+
+    with qtbot.waitSignal(editor.y_position_changed, timeout=100):
+        editor.undo()
+
+    assert editor.y_position == expected
+    assert editor.state.start.y_position == expected
+
+
+def test_y_position_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.y_position
+    editor.y_position = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.y_position == expected
+    assert editor.state.start.y_position == expected
+
+
+def test_y_position_redo_y_position_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.y_position = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.y_position_changed, timeout=100):
+        editor.redo()
+
+    assert editor.y_position == 3
+    assert editor.state.start.y_position == 3
+
+
+def test_y_position_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.y_position = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.y_position == 3
+    assert editor.state.start.y_position == 3
+
+
+def test_action_update_action_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.action_changed, timeout=100):
+        editor.action = 3
+
+    assert editor.action == 3
+    assert editor.state.start.action == 3
+
+
+def test_action_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.action = 3
+
+    assert editor.action == 3
+    assert editor.state.start.action == 3
+
+
+def test_action_undo_action_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.action
+    editor.action = 3
+
+    with qtbot.waitSignal(editor.action_changed, timeout=100):
+        editor.undo()
+
+    assert editor.action == expected
+    assert editor.state.start.action == expected
+
+
+def test_action_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.action
+    editor.action = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.action == expected
+    assert editor.state.start.action == expected
+
+
+def test_action_redo_action_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.action = 7
+    editor.undo()
+
+    with qtbot.waitSignal(editor.action_changed, timeout=100):
+        editor.redo()
+
+    assert editor.action == 7
+    assert editor.state.start.action == 7
+
+
+def test_action_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.action = 7
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.action == 7
+    assert editor.state.start.action == 7
+
+
+def test_generator_palette_update_generator_palette_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.generator_palette_changed, timeout=100):
+        editor.generator_palette = 6
+
+    assert editor.generator_palette == 6
+    assert editor.state.graphics.generator_palette == 6
+
+
+def test_generator_palette_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.generator_palette = 6
+
+    assert editor.generator_palette == 6
+    assert editor.state.graphics.generator_palette == 6
+
+
+def test_generator_palette_undo_generator_palette_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.generator_palette
+    editor.generator_palette = 3
+
+    with qtbot.waitSignal(editor.generator_palette_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_palette == expected
+    assert editor.state.graphics.generator_palette == expected
+
+
+def test_generator_palette_undo_generator_palette_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.generator_palette
+    editor.generator_palette = 6
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_palette == expected
+    assert editor.state.graphics.generator_palette == expected
+
+
+def test_generator_palette_redo_generator_palette_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.generator_palette = 6
+    editor.undo()
+
+    with qtbot.waitSignal(editor.generator_palette_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_palette == 6
+    assert editor.state.graphics.generator_palette == 6
+
+
+def test_generator_palette_redo_generator_palette_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.generator_palette = 6
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_palette == 6
+    assert editor.state.graphics.generator_palette == 6
+
+
+def test_enemy_palette_update_enemy_palette_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.enemy_palette_changed, timeout=100):
+        editor.enemy_palette = 2
+
+    assert editor.enemy_palette == 2
+    assert editor.state.graphics.enemy_palette == 2
+
+
+def test_enemy_palette_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.enemy_palette = 2
+
+    assert editor.enemy_palette == 2
+    assert editor.state.graphics.enemy_palette == 2
+
+
+def test_enemy_palette_undo_enemy_palette_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.enemy_palette
+    editor.enemy_palette = 2
+
+    with qtbot.waitSignal(editor.enemy_palette_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_palette == expected
+    assert editor.state.graphics.enemy_palette == expected
+
+
+def test_enemy_palette_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.enemy_palette
+    editor.enemy_palette = 2
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_palette == expected
+    assert editor.state.graphics.enemy_palette == expected
+
+
+def test_enemy_palette_redo_enemy_palette_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.enemy_palette = 2
+    editor.undo()
+
+    with qtbot.waitSignal(editor.enemy_palette_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_palette == 2
+    assert editor.state.graphics.enemy_palette == 2
+
+
+def test_enemy_palette_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.enemy_palette = 2
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_palette == 2
+    assert editor.state.graphics.enemy_palette == 2
+
+
+def test_graphics_set_update_graphics_set_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.graphics_set_changed, timeout=100):
+        editor.graphics_set = 10
+
+    assert editor.graphics_set == 10
+    assert editor.state.graphics.graphics_set == 10
+
+
+def test_graphics_set_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.graphics_set = 10
+
+    assert editor.graphics_set == 10
+    assert editor.state.graphics.graphics_set == 10
+
+
+def test_graphics_set_undo_graphics_set_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.graphics_set
+    editor.graphics_set = 10
+
+    with qtbot.waitSignal(editor.graphics_set_changed, timeout=100):
+        editor.undo()
+
+    assert editor.graphics_set == expected
+    assert editor.state.graphics.graphics_set == expected
+
+
+def test_graphics_set_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.graphics_set
+    editor.graphics_set = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.graphics_set == expected
+    assert editor.state.graphics.graphics_set == expected
+
+
+def test_graphics_set_redo_graphics_set_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.graphics_set = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.graphics_set_changed, timeout=100):
+        editor.redo()
+
+    assert editor.graphics_set == 10
+    assert editor.state.graphics.graphics_set == 10
+
+
+def test_graphics_set_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.graphics_set = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.graphics_set == 10
+    assert editor.state.graphics.graphics_set == 10
+
+
+def test_next_level_generator_pointer_update_next_level_generator_pointer_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.next_level_generator_pointer_changed, timeout=100):
+        editor.next_level_generator_pointer = 10
+
+    assert editor.next_level_generator_pointer == 10
+    assert editor.state.warp.generator_pointer == 10
+
+
+def test_next_level_generator_pointer_update_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.next_level_generator_pointer = 10
+
+    assert editor.next_level_generator_pointer == 10
+    assert editor.state.warp.generator_pointer == 10
+
+
+def test_next_level_generator_pointer_undo_next_level_generator_pointer_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.next_level_generator_pointer
+    editor.next_level_generator_pointer = 10
+
+    with qtbot.waitSignal(editor.next_level_generator_pointer_changed, timeout=100):
+        editor.undo()
+
+    assert editor.next_level_generator_pointer == expected
+    assert editor.state.warp.generator_pointer == expected
+
+
+def test_next_level_generator_pointer_undo_next_level_generator_pointer_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.next_level_generator_pointer
+    editor.next_level_generator_pointer = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.next_level_generator_pointer == expected
+    assert editor.state.warp.generator_pointer == expected
+
+
+def test_next_level_generator_pointer_redo_next_level_generator_pointer_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.next_level_generator_pointer = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.next_level_generator_pointer_changed, timeout=100):
+        editor.redo()
+
+    assert editor.next_level_generator_pointer == 10
+    assert editor.state.warp.generator_pointer == 10
+
+
+def test_next_level_generator_pointer_redo_next_level_generator_pointer_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.next_level_generator_pointer = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.next_level_generator_pointer == 10
+    assert editor.state.warp.generator_pointer == 10
+
+
+def test_next_level_enemy_pointer_update_next_level_enemy_pointer_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.next_level_enemy_pointer_changed, timeout=100):
+        editor.next_level_enemy_pointer = 10
+
+    assert editor.next_level_enemy_pointer == 10
+    assert editor.state.warp.enemy_pointer == 10
+
+
+def test_next_level_enemy_pointer_update_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.next_level_enemy_pointer = 10
+
+    assert editor.next_level_enemy_pointer == 10
+    assert editor.state.warp.enemy_pointer == 10
+
+
+def test_next_level_enemy_pointer_undo_next_level_enemy_pointer_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.next_level_enemy_pointer
+    editor.next_level_enemy_pointer = 10
+
+    with qtbot.waitSignal(editor.next_level_enemy_pointer_changed, timeout=100):
+        editor.undo()
+
+    assert editor.next_level_enemy_pointer == expected
+    assert editor.state.warp.enemy_pointer == expected
+
+
+def test_next_level_enemy_pointer_undo_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.next_level_enemy_pointer
+    editor.next_level_enemy_pointer = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.next_level_enemy_pointer == expected
+    assert editor.state.warp.enemy_pointer == expected
+
+
+def test_next_level_enemy_pointer_redo_next_level_enemy_pointer_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.next_level_enemy_pointer = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.next_level_enemy_pointer_changed, timeout=100):
+        editor.redo()
+
+    assert editor.next_level_enemy_pointer == 10
+    assert editor.state.warp.enemy_pointer == 10
+
+
+def test_next_level_enemy_pointer_redo_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.next_level_enemy_pointer = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.next_level_enemy_pointer == 10
+    assert editor.state.warp.enemy_pointer == 10
+
+
+def test_next_level_tileset_update_next_level_tileset_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.next_level_tileset_changed, timeout=100):
+        editor.next_level_tileset = 10
+
+    assert editor.next_level_tileset == 10
+    assert editor.state.warp.tileset == 10
+
+
+def test_next_level_tileset_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.next_level_tileset = 10
+
+    assert editor.next_level_tileset == 10
+    assert editor.state.warp.tileset == 10
+
+
+def test_next_level_tileset_undo_next_level_tileset_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.next_level_tileset
+    editor.next_level_tileset = 10
+
+    with qtbot.waitSignal(editor.next_level_tileset_changed, timeout=100):
+        editor.undo()
+
+    assert editor.next_level_tileset == expected
+    assert editor.state.warp.tileset == expected
+
+
+def test_next_level_tileset_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.next_level_tileset
+    editor.next_level_tileset = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.next_level_tileset == expected
+    assert editor.state.warp.tileset == expected
+
+
+def test_next_level_tileset_redo_next_level_tileset_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.next_level_tileset = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.next_level_tileset_changed, timeout=100):
+        editor.redo()
+
+    assert editor.next_level_tileset == 10
+    assert editor.state.warp.tileset == 10
+
+
+def test_next_level_tileset_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.next_level_tileset = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.next_level_tileset == 10
+    assert editor.state.warp.tileset == 10
+
+
+def test_name_updates_name(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.name = "new name"
+    assert editor.name == "new name"
+    assert editor.state.info.display_information.name == "new name"
+
+
+def test_name_update_name_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.name_changed, timeout=100):
+        editor.name = "new name"
+
+    assert editor.name == "new name"
+    assert editor.state.info.display_information.name == "new name"
+
+
+def test_name_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.name = "new name"
+
+    assert editor.name == "new name"
+    assert editor.state.info.display_information.name == "new name"
+
+
+def test_name_undo_name_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.name = "new name"
+
+    with qtbot.waitSignal(editor.name_changed, timeout=100):
+        editor.undo()
+
+    assert editor.name == "name"
+    assert editor.state.info.display_information.name == "name"
+
+
+def test_name_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.name = "new name"
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.name == "name"
+    assert editor.state.info.display_information.name == "name"
+
+
+def test_name_redo_name_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.name = "new name"
+    editor.undo()
+
+    with qtbot.waitSignal(editor.name_changed, timeout=100):
+        editor.redo()
+
+    assert editor.name == "new name"
+    assert editor.state.info.display_information.name == "new name"
+
+
+def test_name_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.name = "new name"
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.name == "new name"
+    assert editor.state.info.display_information.name == "new name"
+
+
+def test_description_update_description_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.description_changed, timeout=100):
+        editor.description = "new description"
+
+    assert editor.description == "new description"
+    assert editor.state.info.display_information.description == "new description"
+
+
+def test_description_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.description = "new description"
+
+    assert editor.description == "new description"
+    assert editor.state.info.display_information.description == "new description"
+
+
+def test_description_undo_description_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.description
+    editor.description = "new description"
+
+    with qtbot.waitSignal(editor.description_changed, timeout=100):
+        editor.undo()
+
+    assert editor.description == expected
+    assert editor.state.info.display_information.description == expected
+
+
+def test_description_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.description
+    editor.description = "new description"
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.description == expected
+    assert editor.state.info.display_information.description == expected
+
+
+def test_description_redo_description_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.description = "new description"
+    editor.undo()
+
+    with qtbot.waitSignal(editor.description_changed, timeout=100):
+        editor.redo()
+
+    assert editor.description == "new description"
+    assert editor.state.info.display_information.description == "new description"
+
+
+def test_description_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.description = "new description"
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.description == "new description"
+    assert editor.state.info.display_information.description == "new description"
+
+
+def test_generator_space_update_generator_space_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.generator_space_changed, timeout=100):
+        editor.generator_space = 10
+
+    assert editor.generator_space == 10
+    assert editor.state.info.generator_size == 10
+
+
+def test_generator_space_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.generator_space = 10
+
+    assert editor.generator_space == 10
+    assert editor.state.info.generator_size == 10
+
+
+def test_generator_space_undo_generator_space_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.generator_space
+    editor.generator_space = 10
+
+    with qtbot.waitSignal(editor.generator_space_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_space == expected
+    assert editor.state.info.generator_size == expected
+
+
+def test_generator_space_undo_generator_space_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.generator_space
+    editor.generator_space = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_space == expected
+    assert editor.state.info.generator_size == expected
+
+
+def test_generator_space_redo_generator_space_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.generator_space = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.generator_space_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_space == 10
+    assert editor.state.info.generator_size == 10
+
+
+def test_generator_space_redo_generator_space_state_changed(
+    qtbot, header_state: HeaderState, empty_file_settings: FileSettings
+):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.generator_space = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_space == 10
+    assert editor.state.info.generator_size == 10
+
+
+def test_enemy_space_update_enemy_space_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.enemy_space_changed, timeout=100):
+        editor.enemy_space = 10
+
+    assert editor.enemy_space == 10
+    assert editor.state.info.enemy_size == 10
+
+
+def test_enemy_space_update_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.enemy_space = 10
+
+    assert editor.enemy_space == 10
+    assert editor.state.info.enemy_size == 10
+
+
+def test_enemy_space_undo_enemy_space_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.enemy_space
+    editor.enemy_space = 10
+
+    with qtbot.waitSignal(editor.enemy_space_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_space == expected
+    assert editor.state.info.enemy_size == expected
+
+
+def test_enemy_space_undo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    expected = editor.enemy_space
+    editor.enemy_space = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_space == expected
+    assert editor.state.info.enemy_size == expected
+
+
+def test_enemy_space_redo_enemy_space_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.enemy_space = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.enemy_space_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_space == 10
+    assert editor.state.info.enemy_size == 10
+
+
+def test_enemy_space_redo_state_changed(qtbot, header_state: HeaderState, empty_file_settings: FileSettings):
+    editor = HeaderEditor(None, header_state, empty_file_settings)
+    editor.enemy_space = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_space == 10
+    assert editor.state.info.enemy_size == 10
+
+
+def test_display_current_page_initialization(
+    qtbot, temp_app, level_bytes: bytearray, empty_file_settings: FileSettings
+):
+    display = HeaderDisplay(
+        temp_app,
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+        level_bytes,
+        empty_file_settings,
+    )
+    assert 0 == display.current_page
+
+
+def test_display_current_page_get_set(qtbot, header_display: HeaderDisplay):
+    header_display.current_page = 1
+    assert 1 == header_display.current_page
+
+
+def test_display_get_data_state(qtbot, level_bytes: bytearray, empty_file_settings: FileSettings):
+    display = HeaderDisplay(
+        QMainWindow(),
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+        level_bytes,
+        empty_file_settings,
+    )
+    assert LevelDataState(0xE, 0, 1, 2, True, False) == display.data
+
+
+def test_display_set_data_state(qtbot, header_display: HeaderDisplay):
+    header_display.data = LevelDataState(0xD, 2, 0, 1, False, True)
+    assert LevelDataState(0xD, 2, 0, 1, False, True) == header_display.data
+
+
+def test_display_get_start_state(qtbot, level_bytes: bytearray, empty_file_settings: FileSettings):
+    display = HeaderDisplay(
+        QMainWindow(),
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+        level_bytes,
+        empty_file_settings,
+    )
+    assert LevelStartState(0, 1, 2) == display.start
+
+
+def test_display_set_start_state(qtbot, header_display: HeaderDisplay):
+    header_display.start = LevelStartState(2, 0, 1)
+    assert LevelStartState(2, 0, 1) == header_display.start
+
+
+def test_display_get_graphics_state(qtbot, level_bytes: bytearray, empty_file_settings: FileSettings):
+    display = HeaderDisplay(
+        QMainWindow(),
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+        level_bytes,
+        empty_file_settings,
+    )
+    assert LevelGraphicsState(7, 3, 4) == display.graphics
+
+
+def test_display_set_graphics_state(qtbot, header_display: HeaderDisplay):
+    header_display.graphics = LevelGraphicsState(0, 1, 2)
+    assert LevelGraphicsState(0, 1, 2) == header_display.graphics
+
+
+def test_display_get_warp_state(qtbot, level_bytes: bytearray, empty_file_settings: FileSettings):
+    display = HeaderDisplay(
+        QMainWindow(),
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+        level_bytes,
+        empty_file_settings,
+    )
+    assert LevelWarpState(0xFFFF, 0xEEEE, 1) == display.warp
+
+
+def test_display_set_warp_state(qtbot, header_display: HeaderDisplay):
+    header_display.warp = LevelWarpState(0xEEEE, 0xFFFF, 0)
+    assert LevelWarpState(0xEEEE, 0xFFFF, 0) == header_display.warp
+
+
+def test_display_get_level_info_state(qtbot, level_bytes: bytearray, empty_file_settings: FileSettings):
+    display = HeaderDisplay(
+        QMainWindow(),
+        LevelDataState(0xE, 0, 1, 2, True, False),
+        LevelStartState(0, 1, 2),
+        LevelGraphicsState(7, 3, 4),
+        LevelWarpState(0xFFFF, 0xEEEE, 1),
+        LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30),
+        level_bytes,
+        empty_file_settings,
+    )
+    assert LevelInformationState(DisplayInformation("name", "desc", []), 0xDDDD, 0xCCCC, 2, 100, 30) == display.info
+
+
+def test_display_set_level_info_state(qtbot, header_display: HeaderDisplay):
+    # Note that the pointers and tileset are not relevant for the info display.
+    header_display.info = LevelInformationState(DisplayInformation("other", "stuff", []), 0xDDDD, 0xCCCC, 2, 50, 15)
+    assert (
+        LevelInformationState(DisplayInformation("other", "stuff", []), 0xDDDD, 0xCCCC, 2, 50, 15)
+        == header_display.info
+    )
+
+
+@given(header_states())
+def test_header_state_to_bytes(header_state: HeaderState):
+    header_state_to_level_header(header_state)

--- a/tests/gui/test_level_data_editor.py
+++ b/tests/gui/test_level_data_editor.py
@@ -1,0 +1,617 @@
+from pytest import fixture
+
+from foundry.gui.LevelDataEditor import (
+    LevelDataDisplay,
+    LevelDataEditor,
+    LevelDataState,
+)
+
+
+@fixture
+def level_data() -> LevelDataState:
+    return LevelDataState(0, 1, 2, 3, True, False)
+
+
+@fixture
+def data_display() -> LevelDataDisplay:
+    return LevelDataDisplay(None, 0, 1, 2, 3, True, False)
+
+
+@fixture
+def data_editor(level_data):
+    return LevelDataEditor(None, level_data)
+
+
+def test_warp_state_initialization():
+    LevelDataState(0, 1, 2, 3, True, False)
+
+
+def test_warp_state_equality():
+    assert LevelDataState(0, 1, 2, 3, True, False) == LevelDataState(0, 1, 2, 3, True, False)
+
+
+def test_warp_state_inequality():
+    assert LevelDataState(0, 1, 2, 3, True, False) != LevelDataState(3, 2, 1, 0, False, True)
+
+
+def test_warp_state_inequality_other():
+    assert LevelDataState(0, 1, 2, 3, True, False) != 1
+
+
+def test_initialization(qtbot, level_data):
+    LevelDataEditor(None, level_data)
+
+
+def test_normal_equality(qtbot, level_data):
+    assert LevelDataEditor(None, level_data) == LevelDataEditor(None, level_data)
+
+
+def test_normal_inequality(qtbot):  # sourcery skip: de-morgan
+    assert LevelDataEditor(None, LevelDataState(0, 1, 2, 3, True, False)) != LevelDataEditor(
+        None, LevelDataState(3, 2, 1, 0, False, True)
+    )
+
+
+def test_equality_undo(qtbot, level_data):
+    editor1 = LevelDataEditor(None, level_data)
+    editor2 = LevelDataEditor(None, level_data)
+    editor1.state = LevelDataState(3, 2, 1, 0, True, False)
+    editor1.undo()
+    assert editor1 != editor2
+
+    editor2.state = LevelDataState(3, 2, 1, 0, True, False)
+
+    assert editor1 != editor2
+
+    editor2.undo()
+    assert editor1 == editor2
+
+
+def test_equality_redo(qtbot, level_data):
+    editor1 = LevelDataEditor(None, level_data)
+    editor2 = LevelDataEditor(None, level_data)
+    editor1.state = LevelDataState(3, 2, 1, 0, True, False)
+    editor1.undo()
+    editor1.redo()
+    assert editor1 != editor2
+
+    editor2.state = LevelDataState(3, 2, 1, 0, True, False)
+
+    assert editor1 == editor2
+
+    editor2.undo()
+    editor2.redo()
+    assert editor1 == editor2
+
+
+def test_inequality_other(qtbot, data_editor):
+    assert data_editor != 3
+
+
+def test_level_length_update_level_length_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.level_length_changed, timeout=100):
+        editor.level_length = 3
+
+    assert editor.level_length == 3
+    assert editor.state.level_length == 3
+
+
+def test_level_length_update_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.level_length = 3
+
+    assert editor.level_length == 3
+    assert editor.state.level_length == 3
+
+
+def test_level_length_undo_level_length_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.level_length
+    editor.level_length = 3
+
+    with qtbot.waitSignal(editor.level_length_changed, timeout=100):
+        editor.undo()
+
+    assert editor.level_length == expected
+    assert editor.state.level_length == expected
+
+
+def test_level_length_undo_level_length_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.level_length
+    editor.level_length = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.level_length == expected
+    assert editor.state.level_length == expected
+
+
+def test_level_length_redo_level_length_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.level_length = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.level_length_changed, timeout=100):
+        editor.redo()
+
+    assert editor.level_length == 3
+    assert editor.state.level_length == 3
+
+
+def test_level_length_redo_level_length_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.level_length = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.level_length == 3
+    assert editor.state.level_length == 3
+
+
+def test_music_update_music_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.music_changed, timeout=100):
+        editor.music = 3
+
+    assert editor.music == 3
+    assert editor.state.music == 3
+
+
+def test_music_update_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.music = 3
+
+    assert editor.music == 3
+    assert editor.state.music == 3
+
+
+def test_music_undo_music_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.music
+    editor.music = 3
+
+    with qtbot.waitSignal(editor.music_changed, timeout=100):
+        editor.undo()
+
+    assert editor.music == expected
+    assert editor.state.music == expected
+
+
+def test_music_undo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.music
+    editor.music = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.music == expected
+    assert editor.state.music == expected
+
+
+def test_music_redo_music_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.music = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.music_changed, timeout=100):
+        editor.redo()
+
+    assert editor.music == 3
+    assert editor.state.music == 3
+
+
+def test_music_redo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.music = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.music == 3
+    assert editor.state.music == 3
+
+
+def test_time_update_time_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.time_changed, timeout=100):
+        editor.time = 3
+
+    assert editor.time == 3
+    assert editor.state.time == 3
+
+
+def test_time_update_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.time = 3
+
+    assert editor.time == 3
+    assert editor.state.time == 3
+
+
+def test_time_undo_time_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.time
+    editor.time = 3
+
+    with qtbot.waitSignal(editor.time_changed, timeout=100):
+        editor.undo()
+
+    assert editor.time == expected
+    assert editor.state.time == expected
+
+
+def test_time_undo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.time
+    editor.time = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.time == expected
+    assert editor.state.time == expected
+
+
+def test_time_redo_time_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.time = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.time_changed, timeout=100):
+        editor.redo()
+
+    assert editor.time == 3
+    assert editor.state.time == 3
+
+
+def test_time_redo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.time = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.time == 3
+    assert editor.state.time == 3
+
+
+def test_scroll_update_scroll_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.scroll_changed, timeout=100):
+        editor.scroll = 2
+
+    assert editor.scroll == 2
+    assert editor.state.scroll == 2
+
+
+def test_scroll_update_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.scroll = 2
+
+    assert editor.scroll == 2
+    assert editor.state.scroll == 2
+
+
+def test_scroll_undo_scroll_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.scroll
+    editor.scroll = 2
+
+    with qtbot.waitSignal(editor.scroll_changed, timeout=100):
+        editor.undo()
+
+    assert editor.scroll == expected
+    assert editor.state.scroll == expected
+
+
+def test_scroll_undo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.scroll
+    editor.scroll = 2
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.scroll == expected
+    assert editor.state.scroll == expected
+
+
+def test_scroll_redo_scroll_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.scroll = 2
+    editor.undo()
+
+    with qtbot.waitSignal(editor.scroll_changed, timeout=100):
+        editor.redo()
+
+    assert editor.scroll == 2
+    assert editor.state.scroll == 2
+
+
+def test_scroll_redo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.scroll = 2
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.scroll == 2
+    assert editor.state.scroll == 2
+
+
+def test_horizontal_update_horizontal_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.horizontal_changed, timeout=100):
+        editor.horizontal = False
+
+    assert not editor.horizontal
+    assert not editor.state.horizontal
+
+
+def test_horizontal_update_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.horizontal = False
+
+    assert not editor.horizontal
+    assert not editor.state.horizontal
+
+
+def test_horizontal_undo_horizontal_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.horizontal
+    editor.horizontal = False
+
+    with qtbot.waitSignal(editor.horizontal_changed, timeout=100):
+        editor.undo()
+
+    assert editor.horizontal == expected
+    assert editor.state.horizontal == expected
+
+
+def test_horizontal_undo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.horizontal
+    editor.horizontal = False
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.horizontal == expected
+    assert editor.state.horizontal == expected
+
+
+def test_horizontal_redo_horizontal_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.horizontal = False
+    editor.undo()
+
+    with qtbot.waitSignal(editor.horizontal_changed, timeout=100):
+        editor.redo()
+
+    assert not editor.horizontal
+    assert not editor.state.horizontal
+
+
+def test_horizontal_redo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.horizontal = False
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert not editor.horizontal
+    assert not editor.state.horizontal
+
+
+def test_pipe_ends_level_update_pipe_ends_level_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.pipe_ends_level_changed, timeout=100):
+        editor.pipe_ends_level = True
+
+    assert editor.pipe_ends_level
+    assert editor.state.pipe_ends_level
+
+
+def test_pipe_ends_level_update_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.pipe_ends_level = True
+
+    assert editor.pipe_ends_level
+    assert editor.state.pipe_ends_level
+
+
+def test_pipe_ends_level_undo_pipe_ends_level_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.pipe_ends_level
+    editor.pipe_ends_level = True
+
+    with qtbot.waitSignal(editor.pipe_ends_level_changed, timeout=100):
+        editor.undo()
+
+    assert editor.pipe_ends_level == expected
+    assert editor.state.pipe_ends_level == expected
+
+
+def test_pipe_ends_level_undo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    expected = editor.pipe_ends_level
+    editor.pipe_ends_level = True
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.pipe_ends_level == expected
+    assert editor.state.pipe_ends_level == expected
+
+
+def test_pipe_ends_level_redo_pipe_ends_level_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.pipe_ends_level = True
+    editor.undo()
+
+    with qtbot.waitSignal(editor.pipe_ends_level_changed, timeout=100):
+        editor.redo()
+
+    assert editor.pipe_ends_level
+    assert editor.state.pipe_ends_level
+
+
+def test_pipe_ends_level_redo_state_changed(qtbot, level_data):
+    editor = LevelDataEditor(None, level_data)
+    editor.pipe_ends_level = True
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.pipe_ends_level
+    assert editor.state.pipe_ends_level
+
+
+def test_display_initialization(qtbot):
+    LevelDataDisplay(None, 0, 1, 2, 3, True, False)
+
+
+def test_display_equality(qtbot):
+    assert LevelDataDisplay(None, 0, 1, 2, 3, True, False) == LevelDataDisplay(None, 0, 1, 2, 3, True, False)
+
+
+def test_display_inequality(qtbot):
+    assert LevelDataDisplay(None, 0, 1, 2, 3, True, False) != LevelDataDisplay(None, 3, 2, 1, 0, False, True)
+
+
+def test_display_other_inequality(qtbot):
+    assert LevelDataDisplay(None, 0, 1, 2, 3, True, False) != 3
+
+
+def test_display_get_level_length(qtbot):
+    display = LevelDataDisplay(None, 0, 1, 2, 3, True, False)
+    assert 0 == display.level_length
+
+
+def test_display_set_level_length(qtbot, data_display: LevelDataDisplay):
+    data_display.level_length = 3
+    assert 3 == data_display.level_length
+
+
+def test_display_get_music(qtbot):
+    display = LevelDataDisplay(None, 0, 1, 2, 3, True, False)
+    assert 1 == display.music
+
+
+def test_display_set_music(qtbot, data_display: LevelDataDisplay):
+    data_display.music = 3
+    assert 3 == data_display.music
+
+
+def test_display_get_etime(qtbot):
+    display = LevelDataDisplay(None, 0, 1, 2, 3, True, False)
+    assert 2 == display.time
+
+
+def test_display_set_time(qtbot, data_display: LevelDataDisplay):
+    data_display.time = 3
+    assert 3 == data_display.time
+
+
+def test_display_set_scroll(qtbot, data_display: LevelDataDisplay):
+    data_display.scroll = 1
+    assert 1 == data_display.scroll
+
+
+def test_display_set_horizontal(qtbot, data_display: LevelDataDisplay):
+    data_display.horizontal = False
+    assert not data_display.horizontal
+
+
+def test_display_set_pipe_ends_level(qtbot, data_display: LevelDataDisplay):
+    data_display.pipe_ends_level = True
+    assert data_display.pipe_ends_level
+
+
+def test_set_level_length(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.level_length = 3
+    assert 3 == data_editor.level_length
+
+
+def test_set_music(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.music = 3
+    assert 3 == data_editor.music
+
+
+def test_set_time(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.time = 3
+    assert 3 == data_editor.time
+
+
+def test_set_scroll(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.scroll = 1
+    assert 1 == data_editor.scroll
+
+
+def test_set_horizontal(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.horizontal = False
+    assert not data_editor.horizontal
+
+
+def test_set_pipe_ends_level(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.pipe_ends_level = True
+    assert data_editor.pipe_ends_level
+
+
+def test_set_level_length_value(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.level_length_editor.setCurrentIndex(3)
+    assert 3 == data_editor.level_length
+
+
+def test_set_music_value(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.music_editor.setCurrentIndex(3)
+    assert 3 == data_editor.music
+
+
+def test_set_time_value(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.time_editor.setCurrentIndex(3)
+    assert 3 == data_editor.time
+
+
+def test_set_scroll_value(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.scroll_editor.setCurrentIndex(1)
+    assert 1 == data_editor.scroll
+
+
+def test_set_horizontal_value(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.horizontal_editor.setChecked(False)
+    assert not data_editor.horizontal
+
+
+def test_set_pipe_ends_level_value(qtbot, data_editor: LevelDataEditor):
+    data_editor._display.pipe_ends_level_editor.setChecked(True)
+    assert data_editor.pipe_ends_level

--- a/tests/gui/test_level_graphics_editor.py
+++ b/tests/gui/test_level_graphics_editor.py
@@ -1,0 +1,368 @@
+from pytest import fixture
+
+from foundry.gui.LevelGraphicsEditor import (
+    LevelGraphicsDisplay,
+    LevelGraphicsEditor,
+    LevelGraphicsState,
+)
+
+
+@fixture
+def warp_info() -> LevelGraphicsState:
+    return LevelGraphicsState(0, 1, 2)
+
+
+@fixture
+def warp_display() -> LevelGraphicsDisplay:
+    return LevelGraphicsDisplay(None, 0, 1, 2)
+
+
+@fixture
+def warp_editor(warp_info):
+    return LevelGraphicsEditor(None, warp_info)
+
+
+def test_warp_state_initialization():
+    LevelGraphicsState(0, 1, 2)
+
+
+def test_warp_state_equality():
+    assert LevelGraphicsState(0, 1, 2) == LevelGraphicsState(0, 1, 2)
+
+
+def test_warp_state_inequality():
+    assert LevelGraphicsState(0, 1, 2) != LevelGraphicsState(2, 1, 0)
+
+
+def test_warp_state_inequality_other():
+    assert LevelGraphicsState(0, 1, 2) != 1
+
+
+def test_initialization(qtbot, warp_info):
+    LevelGraphicsEditor(None, warp_info)
+
+
+def test_normal_equality(qtbot, warp_info):
+    assert LevelGraphicsEditor(None, warp_info) == LevelGraphicsEditor(None, warp_info)
+
+
+def test_normal_inequality(qtbot):  # sourcery skip: de-morgan
+    assert LevelGraphicsEditor(None, LevelGraphicsState(0, 1, 2)) != LevelGraphicsEditor(
+        None, LevelGraphicsState(2, 1, 0)
+    )
+
+
+def test_equality_undo(qtbot, warp_info):
+    editor1 = LevelGraphicsEditor(None, warp_info)
+    editor2 = LevelGraphicsEditor(None, warp_info)
+    editor1.state = LevelGraphicsState(2, 1, 0)
+    editor1.undo()
+    assert editor1 != editor2
+
+    editor2.state = LevelGraphicsState(2, 1, 0)
+
+    assert editor1 != editor2
+
+    editor2.undo()
+    assert editor1 == editor2
+
+
+def test_equality_redo(qtbot, warp_info):
+    editor1 = LevelGraphicsEditor(None, warp_info)
+    editor2 = LevelGraphicsEditor(None, warp_info)
+    editor1.state = LevelGraphicsState(2, 1, 0)
+    editor1.undo()
+    editor1.redo()
+    assert editor1 != editor2
+
+    editor2.state = LevelGraphicsState(2, 1, 0)
+
+    assert editor1 == editor2
+
+    editor2.undo()
+    editor2.redo()
+    assert editor1 == editor2
+
+
+def test_inequality_other(qtbot, warp_editor):
+    assert warp_editor != 5
+
+
+def test_generator_palette_update_generator_palette_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.generator_palette_changed, timeout=100):
+        editor.generator_palette = 7
+
+    assert editor.generator_palette == 7
+    assert editor.state.generator_palette == 7
+
+
+def test_generator_palette_update_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.generator_palette = 7
+
+    assert editor.generator_palette == 7
+    assert editor.state.generator_palette == 7
+
+
+def test_generator_palette_undo_generator_palette_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    expected = editor.generator_palette
+    editor.generator_palette = 3
+
+    with qtbot.waitSignal(editor.generator_palette_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_palette == expected
+    assert editor.state.generator_palette == expected
+
+
+def test_generator_palette_undo_generator_palette_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    expected = editor.generator_palette
+    editor.generator_palette = 7
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_palette == expected
+    assert editor.state.generator_palette == expected
+
+
+def test_generator_palette_redo_generator_palette_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    editor.generator_palette = 7
+    editor.undo()
+
+    with qtbot.waitSignal(editor.generator_palette_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_palette == 7
+    assert editor.state.generator_palette == 7
+
+
+def test_generator_palette_redo_generator_palette_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    editor.generator_palette = 7
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_palette == 7
+    assert editor.state.generator_palette == 7
+
+
+def test_enemy_palette_update_enemy_palette_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.enemy_palette_changed, timeout=100):
+        editor.enemy_palette = 3
+
+    assert editor.enemy_palette == 3
+    assert editor.state.enemy_palette == 3
+
+
+def test_enemy_palette_update_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.enemy_palette = 3
+
+    assert editor.enemy_palette == 3
+    assert editor.state.enemy_palette == 3
+
+
+def test_enemy_palette_undo_enemy_palette_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    expected = editor.enemy_palette
+    editor.enemy_palette = 3
+
+    with qtbot.waitSignal(editor.enemy_palette_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_palette == expected
+    assert editor.state.enemy_palette == expected
+
+
+def test_enemy_palette_undo_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    expected = editor.enemy_palette
+    editor.enemy_palette = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_palette == expected
+    assert editor.state.enemy_palette == expected
+
+
+def test_enemy_palette_redo_enemy_palette_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    editor.enemy_palette = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.enemy_palette_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_palette == 3
+    assert editor.state.enemy_palette == 3
+
+
+def test_enemy_palette_redo_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    editor.enemy_palette = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_palette == 3
+    assert editor.state.enemy_palette == 3
+
+
+def test_graphics_set_update_graphics_set_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.graphics_set_changed, timeout=100):
+        editor.graphics_set = 10
+
+    assert editor.graphics_set == 10
+    assert editor.state.graphics_set == 10
+
+
+def test_graphics_set_update_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.graphics_set = 10
+
+    assert editor.graphics_set == 10
+    assert editor.state.graphics_set == 10
+
+
+def test_graphics_set_undo_graphics_set_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    expected = editor.graphics_set
+    editor.graphics_set = 10
+
+    with qtbot.waitSignal(editor.graphics_set_changed, timeout=100):
+        editor.undo()
+
+    assert editor.graphics_set == expected
+    assert editor.state.graphics_set == expected
+
+
+def test_graphics_set_undo_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    expected = editor.graphics_set
+    editor.graphics_set = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.graphics_set == expected
+    assert editor.state.graphics_set == expected
+
+
+def test_graphics_set_redo_graphics_set_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    editor.graphics_set = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.graphics_set_changed, timeout=100):
+        editor.redo()
+
+    assert editor.graphics_set == 10
+    assert editor.state.graphics_set == 10
+
+
+def test_graphics_set_redo_state_changed(qtbot, warp_info):
+    editor = LevelGraphicsEditor(None, warp_info)
+    editor.graphics_set = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.graphics_set == 10
+    assert editor.state.graphics_set == 10
+
+
+def test_display_initialization(qtbot):
+    LevelGraphicsDisplay(None, 0, 1, 2)
+
+
+def test_display_equality(qtbot):
+    assert LevelGraphicsDisplay(None, 0, 1, 2) == LevelGraphicsDisplay(None, 0, 1, 2)
+
+
+def test_display_inequality(qtbot):
+    assert LevelGraphicsDisplay(None, 0, 1, 2) != LevelGraphicsDisplay(None, 2, 1, 0)
+
+
+def test_display_other_inequality(qtbot):
+    assert LevelGraphicsDisplay(None, 0, 1, 2) != 5
+
+
+def test_display_get_generator_palette(qtbot):
+    display = LevelGraphicsDisplay(None, 0, 1, 2)
+    assert 0 == display.generator_palette
+
+
+def test_display_set_generator_palette(qtbot, warp_display: LevelGraphicsDisplay):
+    warp_display.generator_palette = 5
+    assert 5 == warp_display.generator_palette
+
+
+def test_display_get_enemy_palette(qtbot):
+    display = LevelGraphicsDisplay(None, 0, 1, 2)
+    assert 1 == display.enemy_palette
+
+
+def test_display_set_enemy_palette(qtbot, warp_display: LevelGraphicsDisplay):
+    warp_display.enemy_palette = 3
+    assert 3 == warp_display.enemy_palette
+
+
+def test_display_get_egraphics_set(qtbot):
+    display = LevelGraphicsDisplay(None, 0, 1, 2)
+    assert 2 == display.graphics_set
+
+
+def test_display_set_graphics_set(qtbot, warp_display: LevelGraphicsDisplay):
+    warp_display.graphics_set = 5
+    assert 5 == warp_display.graphics_set
+
+
+def test_set_generator_palette(qtbot, warp_editor: LevelGraphicsEditor):
+    warp_editor._display.generator_palette = 5
+    assert 5 == warp_editor.generator_palette
+
+
+def test_set_enemy_palette(qtbot, warp_editor: LevelGraphicsEditor):
+    warp_editor._display.enemy_palette = 3
+    assert 3 == warp_editor.enemy_palette
+
+
+def test_set_graphics_set(qtbot, warp_editor: LevelGraphicsEditor):
+    warp_editor._display.graphics_set = 5
+    assert 5 == warp_editor.graphics_set
+
+
+def test_set_generator_palette_value(qtbot, warp_editor: LevelGraphicsEditor):
+    warp_editor._display.generator_palette_editor.setValue(5)
+    assert 5 == warp_editor.generator_palette
+
+
+def test_set_enemy_palette_value(qtbot, warp_editor: LevelGraphicsEditor):
+    warp_editor._display.enemy_palette_editor.setValue(3)
+    assert 3 == warp_editor.enemy_palette
+
+
+def test_set_graphics_set_value(qtbot, warp_editor: LevelGraphicsEditor):
+    warp_editor._display.graphics_set_editor.setCurrentIndex(5)
+    assert 5 == warp_editor.graphics_set

--- a/tests/gui/test_level_information_editor.py
+++ b/tests/gui/test_level_information_editor.py
@@ -1,0 +1,470 @@
+from pytest import fixture
+
+from foundry.game.level.util import DisplayInformation, Level
+from foundry.gui.LevelInformationEditor import (
+    LevelInformationEditor,
+    LevelInformationEditorDisplay,
+)
+
+
+@fixture
+def level_info_empty():
+    return Level(DisplayInformation(None, None, []), 0, 1, 2, 3, 4)
+
+
+@fixture
+def level_info():
+    return Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4)
+
+
+@fixture
+def level_display():
+    return LevelInformationEditorDisplay(None, "name", "description", 3, 4)
+
+
+@fixture
+def level_editor(level_info):
+    return LevelInformationEditor(None, level_info)
+
+
+def test_empty_initialization(qtbot, level_info_empty):
+    LevelInformationEditor(None, level_info_empty)
+
+
+def test_initialization(qtbot, level_info):
+    LevelInformationEditor(None, level_info)
+
+
+def test_empty_equality(qtbot):
+    assert LevelInformationEditor(
+        None, Level(DisplayInformation(None, None, []), 0, 1, 2, 3, 4)
+    ) == LevelInformationEditor(None, Level(DisplayInformation(None, None, []), 0, 1, 2, 3, 4))
+
+
+def test_normal_equality(qtbot):
+    assert LevelInformationEditor(
+        None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4)
+    ) == LevelInformationEditor(None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4))
+
+
+def test_normal_empty_inequality(qtbot):  # sourcery skip: de-morgan
+    assert LevelInformationEditor(
+        None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4)
+    ) != LevelInformationEditor(None, Level(DisplayInformation(None, None, []), 0, 1, 2, 3, 4))
+
+
+def test_empty_normal_inequality(qtbot):  # sourcery skip: de-morgan
+    assert LevelInformationEditor(
+        None, Level(DisplayInformation(None, None, []), 0, 1, 2, 3, 4)
+    ) != LevelInformationEditor(None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4))
+
+
+def test_equality_undo(qtbot):
+    editor1 = LevelInformationEditor(None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4))
+    editor2 = LevelInformationEditor(None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4))
+    editor1.state = ("new name", "new description", 1, 2)
+    editor1.undo()
+    assert editor1 != editor2
+
+    editor2.state = ("new name", "new description", 1, 2)
+
+    assert editor1 != editor2
+
+    editor2.undo()
+    assert editor1 == editor2
+
+
+def test_equality_redo(qtbot):
+    editor1 = LevelInformationEditor(None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4))
+    editor2 = LevelInformationEditor(None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4))
+    editor1.state = ("new name", "new description", 1, 2)
+    editor1.undo()
+    editor1.redo()
+    assert editor1 != editor2
+
+    editor2.state = ("new name", "new description", 1, 2)
+
+    assert editor1 == editor2
+
+    editor2.undo()
+    editor2.redo()
+    assert editor1 == editor2
+
+
+def test_inequality_other(qtbot):
+    assert LevelInformationEditor(None, Level(DisplayInformation("name", "description", []), 0, 1, 2, 3, 4)) != 5
+
+
+def test_name_updates_name(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.name = "new name"
+    assert editor.name == "new name"
+    assert editor.level.display_information.name == "new name"
+
+
+def test_name_update_name_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+
+    with qtbot.waitSignal(editor.name_changed, timeout=100):
+        editor.name = "new name"
+
+    assert editor.name == "new name"
+    assert editor.level.display_information.name == "new name"
+
+
+def test_name_update_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.name = "new name"
+
+    assert editor.name == "new name"
+    assert editor.level.display_information.name == "new name"
+
+
+def test_name_undo_name_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.name = "new name"
+
+    with qtbot.waitSignal(editor.name_changed, timeout=100):
+        editor.undo()
+
+    assert editor.name == "name"
+    assert editor.level.display_information.name == "name"
+
+
+def test_name_undo_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.name = "new name"
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.name == "name"
+    assert editor.level.display_information.name == "name"
+
+
+def test_name_redo_name_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.name = "new name"
+    editor.undo()
+
+    with qtbot.waitSignal(editor.name_changed, timeout=100):
+        editor.redo()
+
+    assert editor.name == "new name"
+    assert editor.level.display_information.name == "new name"
+
+
+def test_name_redo_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.name = "new name"
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.name == "new name"
+    assert editor.level.display_information.name == "new name"
+
+
+def test_description_update_description_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+
+    with qtbot.waitSignal(editor.description_changed, timeout=100):
+        editor.description = "new description"
+
+    assert editor.description == "new description"
+    assert editor.level.display_information.description == "new description"
+
+
+def test_description_update_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.description = "new description"
+
+    assert editor.description == "new description"
+    assert editor.level.display_information.description == "new description"
+
+
+def test_description_undo_description_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.description = "new description"
+
+    with qtbot.waitSignal(editor.description_changed, timeout=100):
+        editor.undo()
+
+    assert editor.description == "description"
+    assert editor.level.display_information.description == "description"
+
+
+def test_description_undo_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.description = "new description"
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.description == "description"
+    assert editor.level.display_information.description == "description"
+
+
+def test_description_redo_description_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.description = "new description"
+    editor.undo()
+
+    with qtbot.waitSignal(editor.description_changed, timeout=100):
+        editor.redo()
+
+    assert editor.description == "new description"
+    assert editor.level.display_information.description == "new description"
+
+
+def test_description_redo_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.description = "new description"
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.description == "new description"
+    assert editor.level.display_information.description == "new description"
+
+
+def test_generator_space_update_generator_space_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+
+    with qtbot.waitSignal(editor.generator_space_changed, timeout=100):
+        editor.generator_space = 10
+
+    assert editor.generator_space == 10
+    assert editor.level.generator_size == 10
+
+
+def test_generator_space_update_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.generator_space = 10
+
+    assert editor.generator_space == 10
+    assert editor.level.generator_size == 10
+
+
+def test_generator_space_undo_generator_space_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    expected = editor.generator_space
+    editor.generator_space = 10
+
+    with qtbot.waitSignal(editor.generator_space_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_space == expected
+    assert editor.level.generator_size == expected
+
+
+def test_generator_space_undo_generator_space_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    expected = editor.generator_space
+    editor.generator_space = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_space == expected
+    assert editor.level.generator_size == expected
+
+
+def test_generator_space_redo_generator_space_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.generator_space = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.generator_space_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_space == 10
+    assert editor.level.generator_size == 10
+
+
+def test_generator_space_redo_generator_space_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.generator_space = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_space == 10
+    assert editor.level.generator_size == 10
+
+
+def test_enemy_space_update_enemy_space_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+
+    with qtbot.waitSignal(editor.enemy_space_changed, timeout=100):
+        editor.enemy_space = 10
+
+    assert editor.enemy_space == 10
+    assert editor.level.enemy_size == 10
+
+
+def test_enemy_space_update_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.enemy_space = 10
+
+    assert editor.enemy_space == 10
+    assert editor.level.enemy_size == 10
+
+
+def test_enemy_space_undo_enemy_space_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    expected = editor.enemy_space
+    editor.enemy_space = 10
+
+    with qtbot.waitSignal(editor.enemy_space_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_space == expected
+    assert editor.level.enemy_size == expected
+
+
+def test_enemy_space_undo_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    expected = editor.enemy_space
+    editor.enemy_space = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_space == expected
+    assert editor.level.enemy_size == expected
+
+
+def test_enemy_space_redo_enemy_space_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.enemy_space = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.enemy_space_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_space == 10
+    assert editor.level.enemy_size == 10
+
+
+def test_enemy_space_redo_state_changed(qtbot, level_info):
+    editor = LevelInformationEditor(None, level_info)
+    editor.enemy_space = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_space == 10
+    assert editor.level.enemy_size == 10
+
+
+def test_display_initialization(qtbot):
+    LevelInformationEditorDisplay(None, "name", "description", 3, 4)
+
+
+def test_display_equality(qtbot):
+    assert LevelInformationEditorDisplay(None, "name", "description", 3, 4) == LevelInformationEditorDisplay(
+        None, "name", "description", 3, 4
+    )
+
+
+def test_display_inequality(qtbot):
+    assert LevelInformationEditorDisplay(None, "name", "description", 3, 4) != LevelInformationEditorDisplay(
+        None, "name", "description", 3, 5
+    )
+
+
+def test_display_other_inequality(qtbot):
+    assert LevelInformationEditorDisplay(None, "name", "description", 3, 4) != 5
+
+
+def test_display_get_name(qtbot):
+    display = LevelInformationEditorDisplay(None, "name", "description", 3, 4)
+    assert "name" == display.name
+
+
+def test_display_set_name(qtbot, level_display: LevelInformationEditorDisplay):
+    level_display.name = "new name"
+    assert "new name" == level_display.name
+
+
+def test_display_get_description(qtbot):
+    display = LevelInformationEditorDisplay(None, "name", "description", 3, 4)
+    assert "description" == display.description
+
+
+def test_display_set_description(qtbot, level_display: LevelInformationEditorDisplay):
+    level_display.description = "new description"
+    assert "new description" == level_display.description
+
+
+def test_display_get_generator_space(qtbot):
+    display = LevelInformationEditorDisplay(None, "name", "description", 3, 4)
+    assert 3 == display.generator_space
+
+
+def test_display_set_generator_space(qtbot, level_display: LevelInformationEditorDisplay):
+    level_display.generator_space = 5
+    assert 5 == level_display.generator_space
+
+
+def test_display_get_enemy_space(qtbot):
+    display = LevelInformationEditorDisplay(None, "name", "description", 3, 4)
+    assert 4 == display.enemy_space
+
+
+def test_display_set_enemy_space(qtbot, level_display: LevelInformationEditorDisplay):
+    level_display.enemy_space = 5
+    assert 5 == level_display.enemy_space
+
+
+def test_set_name(qtbot, level_editor: LevelInformationEditor):
+    level_editor._display.name = "new name"
+    assert "new name" == level_editor.name
+
+
+def test_set_description(qtbot, level_editor: LevelInformationEditor):
+    level_editor._display.description = "new description"
+    assert "new description" == level_editor.description
+
+
+def test_set_generator_space(qtbot, level_editor: LevelInformationEditor):
+    level_editor._display.generator_space = 5
+    assert 5 == level_editor.generator_space
+
+
+def test_set_enemy_space(qtbot, level_editor: LevelInformationEditor):
+    level_editor._display.enemy_space = 5
+    assert 5 == level_editor.enemy_space
+
+
+def test_set_name_test(qtbot, level_editor: LevelInformationEditor):
+    level_editor._display.name_editor.setText("new name")
+    assert "new name" == level_editor.name
+
+
+def test_set_description_text(qtbot, level_editor: LevelInformationEditor):
+    level_editor._display.description_editor.setText("new description")
+    assert "new description" == level_editor.description
+
+
+def test_set_generator_space_value(qtbot, level_editor: LevelInformationEditor):
+    level_editor._display.generator_space_editor.setValue(5)
+    assert 5 == level_editor.generator_space
+
+
+def test_set_enemy_space_value(qtbot, level_editor: LevelInformationEditor):
+    level_editor._display.enemy_space_editor.setValue(5)
+    assert 5 == level_editor.enemy_space

--- a/tests/gui/test_level_start_editor.py
+++ b/tests/gui/test_level_start_editor.py
@@ -1,0 +1,366 @@
+from pytest import fixture
+
+from foundry.gui.LevelStartEditor import (
+    LevelStartDisplay,
+    LevelStartEditor,
+    LevelStartState,
+)
+
+
+@fixture
+def warp_info() -> LevelStartState:
+    return LevelStartState(0, 1, 2)
+
+
+@fixture
+def warp_display() -> LevelStartDisplay:
+    return LevelStartDisplay(None, 0, 1, 2)
+
+
+@fixture
+def warp_editor(warp_info):
+    return LevelStartEditor(None, warp_info)
+
+
+def test_warp_state_initialization():
+    LevelStartState(0, 1, 2)
+
+
+def test_warp_state_equality():
+    assert LevelStartState(0, 1, 2) == LevelStartState(0, 1, 2)
+
+
+def test_warp_state_inequality():
+    assert LevelStartState(0, 1, 2) != LevelStartState(2, 1, 0)
+
+
+def test_warp_state_inequality_other():
+    assert LevelStartState(0, 1, 2) != 1
+
+
+def test_initialization(qtbot, warp_info):
+    LevelStartEditor(None, warp_info)
+
+
+def test_normal_equality(qtbot, warp_info):
+    assert LevelStartEditor(None, warp_info) == LevelStartEditor(None, warp_info)
+
+
+def test_normal_inequality(qtbot):  # sourcery skip: de-morgan
+    assert LevelStartEditor(None, LevelStartState(0, 1, 2)) != LevelStartEditor(None, LevelStartState(2, 1, 0))
+
+
+def test_equality_undo(qtbot, warp_info):
+    editor1 = LevelStartEditor(None, warp_info)
+    editor2 = LevelStartEditor(None, warp_info)
+    editor1.state = LevelStartState(2, 1, 0)
+    editor1.undo()
+    assert editor1 != editor2
+
+    editor2.state = LevelStartState(2, 1, 0)
+
+    assert editor1 != editor2
+
+    editor2.undo()
+    assert editor1 == editor2
+
+
+def test_equality_redo(qtbot, warp_info):
+    editor1 = LevelStartEditor(None, warp_info)
+    editor2 = LevelStartEditor(None, warp_info)
+    editor1.state = LevelStartState(2, 1, 0)
+    editor1.undo()
+    editor1.redo()
+    assert editor1 != editor2
+
+    editor2.state = LevelStartState(2, 1, 0)
+
+    assert editor1 == editor2
+
+    editor2.undo()
+    editor2.redo()
+    assert editor1 == editor2
+
+
+def test_inequality_other(qtbot, warp_editor):
+    assert warp_editor != 3
+
+
+def test_x_position_update_x_position_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.x_position_changed, timeout=100):
+        editor.x_position = 3
+
+    assert editor.x_position == 3
+    assert editor.state.x_position == 3
+
+
+def test_x_position_update_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.x_position = 3
+
+    assert editor.x_position == 3
+    assert editor.state.x_position == 3
+
+
+def test_x_position_undo_x_position_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    expected = editor.x_position
+    editor.x_position = 3
+
+    with qtbot.waitSignal(editor.x_position_changed, timeout=100):
+        editor.undo()
+
+    assert editor.x_position == expected
+    assert editor.state.x_position == expected
+
+
+def test_x_position_undo_x_position_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    expected = editor.x_position
+    editor.x_position = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.x_position == expected
+    assert editor.state.x_position == expected
+
+
+def test_x_position_redo_x_position_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    editor.x_position = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.x_position_changed, timeout=100):
+        editor.redo()
+
+    assert editor.x_position == 3
+    assert editor.state.x_position == 3
+
+
+def test_x_position_redo_x_position_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    editor.x_position = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.x_position == 3
+    assert editor.state.x_position == 3
+
+
+def test_y_position_update_y_position_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.y_position_changed, timeout=100):
+        editor.y_position = 3
+
+    assert editor.y_position == 3
+    assert editor.state.y_position == 3
+
+
+def test_y_position_update_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.y_position = 3
+
+    assert editor.y_position == 3
+    assert editor.state.y_position == 3
+
+
+def test_y_position_undo_y_position_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    expected = editor.y_position
+    editor.y_position = 3
+
+    with qtbot.waitSignal(editor.y_position_changed, timeout=100):
+        editor.undo()
+
+    assert editor.y_position == expected
+    assert editor.state.y_position == expected
+
+
+def test_y_position_undo_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    expected = editor.y_position
+    editor.y_position = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.y_position == expected
+    assert editor.state.y_position == expected
+
+
+def test_y_position_redo_y_position_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    editor.y_position = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.y_position_changed, timeout=100):
+        editor.redo()
+
+    assert editor.y_position == 3
+    assert editor.state.y_position == 3
+
+
+def test_y_position_redo_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    editor.y_position = 3
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.y_position == 3
+    assert editor.state.y_position == 3
+
+
+def test_action_update_action_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.action_changed, timeout=100):
+        editor.action = 3
+
+    assert editor.action == 3
+    assert editor.state.action == 3
+
+
+def test_action_update_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.action = 3
+
+    assert editor.action == 3
+    assert editor.state.action == 3
+
+
+def test_action_undo_action_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    expected = editor.action
+    editor.action = 3
+
+    with qtbot.waitSignal(editor.action_changed, timeout=100):
+        editor.undo()
+
+    assert editor.action == expected
+    assert editor.state.action == expected
+
+
+def test_action_undo_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    expected = editor.action
+    editor.action = 3
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.action == expected
+    assert editor.state.action == expected
+
+
+def test_action_redo_action_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    editor.action = 7
+    editor.undo()
+
+    with qtbot.waitSignal(editor.action_changed, timeout=100):
+        editor.redo()
+
+    assert editor.action == 7
+    assert editor.state.action == 7
+
+
+def test_action_redo_state_changed(qtbot, warp_info):
+    editor = LevelStartEditor(None, warp_info)
+    editor.action = 7
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.action == 7
+    assert editor.state.action == 7
+
+
+def test_display_initialization(qtbot):
+    LevelStartDisplay(None, 0, 1, 2)
+
+
+def test_display_equality(qtbot):
+    assert LevelStartDisplay(None, 0, 1, 2) == LevelStartDisplay(None, 0, 1, 2)
+
+
+def test_display_inequality(qtbot):
+    assert LevelStartDisplay(None, 0, 1, 2) != LevelStartDisplay(None, 2, 1, 0)
+
+
+def test_display_other_inequality(qtbot):
+    assert LevelStartDisplay(None, 0, 1, 2) != 3
+
+
+def test_display_get_x_position(qtbot):
+    display = LevelStartDisplay(None, 0, 1, 2)
+    assert 0 == display.x_position
+
+
+def test_display_set_x_position(qtbot, warp_display: LevelStartDisplay):
+    warp_display.x_position = 3
+    assert 3 == warp_display.x_position
+
+
+def test_display_get_y_position(qtbot):
+    display = LevelStartDisplay(None, 0, 1, 2)
+    assert 1 == display.y_position
+
+
+def test_display_set_y_position(qtbot, warp_display: LevelStartDisplay):
+    warp_display.y_position = 3
+    assert 3 == warp_display.y_position
+
+
+def test_display_get_eaction(qtbot):
+    display = LevelStartDisplay(None, 0, 1, 2)
+    assert 2 == display.action
+
+
+def test_display_set_action(qtbot, warp_display: LevelStartDisplay):
+    warp_display.action = 3
+    assert 3 == warp_display.action
+
+
+def test_set_x_position(qtbot, warp_editor: LevelStartEditor):
+    warp_editor._display.x_position = 3
+    assert 3 == warp_editor.x_position
+
+
+def test_set_y_position(qtbot, warp_editor: LevelStartEditor):
+    warp_editor._display.y_position = 3
+    assert 3 == warp_editor.y_position
+
+
+def test_set_action(qtbot, warp_editor: LevelStartEditor):
+    warp_editor._display.action = 3
+    assert 3 == warp_editor.action
+
+
+def test_set_x_position_value(qtbot, warp_editor: LevelStartEditor):
+    warp_editor._display.x_position_editor.setCurrentIndex(3)
+    assert 3 == warp_editor.x_position
+
+
+def test_set_y_position_value(qtbot, warp_editor: LevelStartEditor):
+    warp_editor._display.y_position_editor.setCurrentIndex(3)
+    assert 3 == warp_editor.y_position
+
+
+def test_set_action_value(qtbot, warp_editor: LevelStartEditor):
+    warp_editor._display.action_editor.setCurrentIndex(3)
+    assert 3 == warp_editor.action

--- a/tests/gui/test_level_view.py
+++ b/tests/gui/test_level_view.py
@@ -5,7 +5,6 @@ from PySide6.QtGui import Qt, QWheelEvent
 from foundry.game.gfx.objects.LevelObject import LevelObject
 from foundry.gui.HeaderEditor import HeaderEditor
 from foundry.gui.LevelView import LevelView
-from foundry.gui.settings import SETTINGS
 from foundry.smb3parse.objects.object_set import PLAINS_OBJECT_SET
 
 
@@ -80,7 +79,7 @@ def test_wheel_event(scroll_amount, coordinates, wheel_delta, type_change, main_
     object_under_cursor = level_view.object_at(x, y)
     original_type = object_under_cursor.type
 
-    SETTINGS["object_scroll_enabled"] = True
+    main_window.user_settings.object_scroll_enabled = True
 
     # WHEN level view is scrolled horizontally, the object is selected and the scroll wheel is used on it
     main_window.scroll_panel.horizontalScrollBar().setMaximum(level_view.width())

--- a/tests/gui/test_level_warp_editor.py
+++ b/tests/gui/test_level_warp_editor.py
@@ -1,0 +1,366 @@
+from pytest import fixture
+
+from foundry.gui.LevelWarpEditor import (
+    LevelWarpDisplay,
+    LevelWarpEditor,
+    LevelWarpState,
+)
+
+
+@fixture
+def warp_info() -> LevelWarpState:
+    return LevelWarpState(0, 1, 2)
+
+
+@fixture
+def warp_display() -> LevelWarpDisplay:
+    return LevelWarpDisplay(None, 0, 1, 2)
+
+
+@fixture
+def warp_editor(warp_info):
+    return LevelWarpEditor(None, warp_info)
+
+
+def test_warp_state_initialization():
+    LevelWarpState(0, 1, 2)
+
+
+def test_warp_state_equality():
+    assert LevelWarpState(0, 1, 2) == LevelWarpState(0, 1, 2)
+
+
+def test_warp_state_inequality():
+    assert LevelWarpState(0, 1, 2) != LevelWarpState(2, 1, 0)
+
+
+def test_warp_state_inequality_other():
+    assert LevelWarpState(0, 1, 2) != 1
+
+
+def test_initialization(qtbot, warp_info):
+    LevelWarpEditor(None, warp_info)
+
+
+def test_normal_equality(qtbot, warp_info):
+    assert LevelWarpEditor(None, warp_info) == LevelWarpEditor(None, warp_info)
+
+
+def test_normal_inequality(qtbot):  # sourcery skip: de-morgan
+    assert LevelWarpEditor(None, LevelWarpState(0, 1, 2)) != LevelWarpEditor(None, LevelWarpState(2, 1, 0))
+
+
+def test_equality_undo(qtbot, warp_info):
+    editor1 = LevelWarpEditor(None, warp_info)
+    editor2 = LevelWarpEditor(None, warp_info)
+    editor1.state = LevelWarpState(2, 1, 0)
+    editor1.undo()
+    assert editor1 != editor2
+
+    editor2.state = LevelWarpState(2, 1, 0)
+
+    assert editor1 != editor2
+
+    editor2.undo()
+    assert editor1 == editor2
+
+
+def test_equality_redo(qtbot, warp_info):
+    editor1 = LevelWarpEditor(None, warp_info)
+    editor2 = LevelWarpEditor(None, warp_info)
+    editor1.state = LevelWarpState(2, 1, 0)
+    editor1.undo()
+    editor1.redo()
+    assert editor1 != editor2
+
+    editor2.state = LevelWarpState(2, 1, 0)
+
+    assert editor1 == editor2
+
+    editor2.undo()
+    editor2.redo()
+    assert editor1 == editor2
+
+
+def test_inequality_other(qtbot, warp_editor):
+    assert warp_editor != 5
+
+
+def test_generator_pointer_update_generator_pointer_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.generator_pointer_changed, timeout=100):
+        editor.generator_pointer = 10
+
+    assert editor.generator_pointer == 10
+    assert editor.state.generator_pointer == 10
+
+
+def test_generator_pointer_update_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.generator_pointer = 10
+
+    assert editor.generator_pointer == 10
+    assert editor.state.generator_pointer == 10
+
+
+def test_generator_pointer_undo_generator_pointer_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    expected = editor.generator_pointer
+    editor.generator_pointer = 10
+
+    with qtbot.waitSignal(editor.generator_pointer_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_pointer == expected
+    assert editor.state.generator_pointer == expected
+
+
+def test_generator_pointer_undo_generator_pointer_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    expected = editor.generator_pointer
+    editor.generator_pointer = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.generator_pointer == expected
+    assert editor.state.generator_pointer == expected
+
+
+def test_generator_pointer_redo_generator_pointer_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    editor.generator_pointer = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.generator_pointer_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_pointer == 10
+    assert editor.state.generator_pointer == 10
+
+
+def test_generator_pointer_redo_generator_pointer_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    editor.generator_pointer = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.generator_pointer == 10
+    assert editor.state.generator_pointer == 10
+
+
+def test_enemy_pointer_update_enemy_pointer_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.enemy_pointer_changed, timeout=100):
+        editor.enemy_pointer = 10
+
+    assert editor.enemy_pointer == 10
+    assert editor.state.enemy_pointer == 10
+
+
+def test_enemy_pointer_update_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.enemy_pointer = 10
+
+    assert editor.enemy_pointer == 10
+    assert editor.state.enemy_pointer == 10
+
+
+def test_enemy_pointer_undo_enemy_pointer_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    expected = editor.enemy_pointer
+    editor.enemy_pointer = 10
+
+    with qtbot.waitSignal(editor.enemy_pointer_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_pointer == expected
+    assert editor.state.enemy_pointer == expected
+
+
+def test_enemy_pointer_undo_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    expected = editor.enemy_pointer
+    editor.enemy_pointer = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.enemy_pointer == expected
+    assert editor.state.enemy_pointer == expected
+
+
+def test_enemy_pointer_redo_enemy_pointer_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    editor.enemy_pointer = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.enemy_pointer_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_pointer == 10
+    assert editor.state.enemy_pointer == 10
+
+
+def test_enemy_pointer_redo_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    editor.enemy_pointer = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.enemy_pointer == 10
+    assert editor.state.enemy_pointer == 10
+
+
+def test_tileset_update_tileset_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.tileset_changed, timeout=100):
+        editor.tileset = 10
+
+    assert editor.tileset == 10
+    assert editor.state.tileset == 10
+
+
+def test_tileset_update_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.tileset = 10
+
+    assert editor.tileset == 10
+    assert editor.state.tileset == 10
+
+
+def test_tileset_undo_tileset_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    expected = editor.tileset
+    editor.tileset = 10
+
+    with qtbot.waitSignal(editor.tileset_changed, timeout=100):
+        editor.undo()
+
+    assert editor.tileset == expected
+    assert editor.state.tileset == expected
+
+
+def test_tileset_undo_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    expected = editor.tileset
+    editor.tileset = 10
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.undo()
+
+    assert editor.tileset == expected
+    assert editor.state.tileset == expected
+
+
+def test_tileset_redo_tileset_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    editor.tileset = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.tileset_changed, timeout=100):
+        editor.redo()
+
+    assert editor.tileset == 10
+    assert editor.state.tileset == 10
+
+
+def test_tileset_redo_state_changed(qtbot, warp_info):
+    editor = LevelWarpEditor(None, warp_info)
+    editor.tileset = 10
+    editor.undo()
+
+    with qtbot.waitSignal(editor.state_changed, timeout=100):
+        editor.redo()
+
+    assert editor.tileset == 10
+    assert editor.state.tileset == 10
+
+
+def test_display_initialization(qtbot):
+    LevelWarpDisplay(None, 0, 1, 2)
+
+
+def test_display_equality(qtbot):
+    assert LevelWarpDisplay(None, 0, 1, 2) == LevelWarpDisplay(None, 0, 1, 2)
+
+
+def test_display_inequality(qtbot):
+    assert LevelWarpDisplay(None, 0, 1, 2) != LevelWarpDisplay(None, 2, 1, 0)
+
+
+def test_display_other_inequality(qtbot):
+    assert LevelWarpDisplay(None, 0, 1, 2) != 5
+
+
+def test_display_get_generator_pointer(qtbot):
+    display = LevelWarpDisplay(None, 0, 1, 2)
+    assert 0 == display.generator_pointer
+
+
+def test_display_set_generator_pointer(qtbot, warp_display: LevelWarpDisplay):
+    warp_display.generator_pointer = 5
+    assert 5 == warp_display.generator_pointer
+
+
+def test_display_get_enemy_pointer(qtbot):
+    display = LevelWarpDisplay(None, 0, 1, 2)
+    assert 1 == display.enemy_pointer
+
+
+def test_display_set_enemy_pointer(qtbot, warp_display: LevelWarpDisplay):
+    warp_display.enemy_pointer = 5
+    assert 5 == warp_display.enemy_pointer
+
+
+def test_display_get_etileset(qtbot):
+    display = LevelWarpDisplay(None, 0, 1, 2)
+    assert 2 == display.tileset
+
+
+def test_display_set_tileset(qtbot, warp_display: LevelWarpDisplay):
+    warp_display.tileset = 5
+    assert 5 == warp_display.tileset
+
+
+def test_set_generator_pointer(qtbot, warp_editor: LevelWarpEditor):
+    warp_editor._display.generator_pointer = 5
+    assert 5 == warp_editor.generator_pointer
+
+
+def test_set_enemy_pointer(qtbot, warp_editor: LevelWarpEditor):
+    warp_editor._display.enemy_pointer = 5
+    assert 5 == warp_editor.enemy_pointer
+
+
+def test_set_tileset(qtbot, warp_editor: LevelWarpEditor):
+    warp_editor._display.tileset = 5
+    assert 5 == warp_editor.tileset
+
+
+def test_set_generator_pointer_value(qtbot, warp_editor: LevelWarpEditor):
+    warp_editor._display.generator_pointer_editor.setValue(5)
+    assert 5 == warp_editor.generator_pointer
+
+
+def test_set_enemy_pointer_value(qtbot, warp_editor: LevelWarpEditor):
+    warp_editor._display.enemy_pointer_editor.setValue(5)
+    assert 5 == warp_editor.enemy_pointer
+
+
+def test_set_tileset_value(qtbot, warp_editor: LevelWarpEditor):
+    warp_editor._display.tileset_editor.setCurrentIndex(5)
+    assert 5 == warp_editor.tileset

--- a/tests/gui/test_object_dropdown.py
+++ b/tests/gui/test_object_dropdown.py
@@ -11,7 +11,7 @@ def test_object_update_on_level_change(main_window):
 
     # WHEN the level is changed
     main_window.manager.controller.update_level(
-        "Level 1-2", level_1_2_object_address, level_1_2_enemy_address, HILLY_OBJECT_SET
+        "PydanticLevel 1-2", level_1_2_object_address, level_1_2_enemy_address, HILLY_OBJECT_SET
     )
 
     assert original_object_set != main_window.manager.controller.level_ref.level.object_set_number

--- a/tests/smb3parse/levels/test_find_first_level_coordinates.py
+++ b/tests/smb3parse/levels/test_find_first_level_coordinates.py
@@ -16,7 +16,7 @@ def test_find_first_level_coordinates(rom: Rom):
         if coordinate.tile() == TILE_LEVEL_1:
             break
     else:
-        pytest.fail("Didn't find Level 1 in this world.")
+        pytest.fail("Didn't find PydanticLevel 1 in this world.")
         return
 
     assert coordinate.level_info is not None


### PR DESCRIPTION
Closes: #178, #130 

- Refactor SETTINGS to filesettings and usersettings to handle file specific and user specific settings, respectively.
- Add a equality method for the undo controller to help with comparisons.
- Refactor to header editor to add multiple tests.
- Add ability to select the level generator and object space.
- Add ability to change level name and description.