### PR TITLE
Fix load_settings not catching ValidationException

### DIFF
--- a/foundry/gui/settings.py
+++ b/foundry/gui/settings.py
@@ -1,9 +1,10 @@
 from enum import Enum
 from json import loads
 from os.path import exists
+from pathlib import Path
 
 from attr import attrs, field
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from qt_material import build_stylesheet
 
 from foundry import default_settings_path, default_styles_path, file_settings_path
@@ -301,7 +302,7 @@ def save_file_settings(file_id: str, file_settings: FileSettings):
         settings_file.write(to_pydantic_file_settings(file_settings).json(indent=4))
 
 
-def load_settings() -> UserSettings:
+def load_settings(file_path: Path = default_settings_path) -> UserSettings:
     """
     Provides the user settings.
 
@@ -311,9 +312,9 @@ def load_settings() -> UserSettings:
         The current user settings.
     """
     try:
-        with open(str(default_settings_path), "r") as settings_file:
+        with open(str(file_path), "r") as settings_file:
             return PydanticUserSettings(**loads(settings_file.read())).to_user_settings()
-    except (TypeError, FileNotFoundError):
+    except (TypeError, FileNotFoundError, ValidationError):
         return PydanticUserSettings().to_user_settings()
 
 

--- a/tests/gui/test_settings.py
+++ b/tests/gui/test_settings.py
@@ -1,0 +1,29 @@
+from foundry.gui.settings import PydanticUserSettings, load_settings
+
+MALFORMED_SETTINGS = """
+{
+    "block_transparency": true,
+    "default_powerup": 0,
+    "draw_autoscroll": false,
+    "draw_expansion": false,
+    "draw_grid": false,
+    "draw_invisible_items": true,
+    "draw_items_in_blocks": true,
+    "draw_jump_on_objects": true,
+    "draw_jumps": false,
+    "draw_mario": true,
+    "gui_style": "",
+    "instaplay_arguments": "%f",
+    "instaplay_emulator": "fceux",
+    "object_scroll_enabled": false,
+    "object_tooltip_enabled": true,
+    "resize_mode": "LMB"
+}
+"""
+
+
+def test_load_settings_validation_exception(tmp_path):
+    settings_path = tmp_path / "test_setting.json"
+    settings_path.write_text(MALFORMED_SETTINGS)
+
+    assert PydanticUserSettings().to_user_settings() == load_settings(settings_path)


### PR DESCRIPTION
Closes: #214 

- Fix `load_settings` not catching `ValidationException`.
- Add test to stop this from occurring in the future.